### PR TITLE
Build: temporarily use Iceberg 1.9.0-SNAPSHOT

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,12 +37,6 @@ jobs:
 
     steps:
 
-      - name: Checkout Apache Iceberg
-        uses: actions/checkout@v4
-        with:
-          repository: apache/iceberg
-          path: iceberg
-
       - name: Checkout Apache Polaris
         uses: actions/checkout@v4
         with:
@@ -68,18 +62,6 @@ jobs:
           # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
           # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
           validate-wrappers: false
-
-      - name: Gradle Build Apache Iceberg
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: |
-          cd $GITHUB_WORKSPACE/iceberg
-          echo "1.9.0-authmgr" > version.txt
-          ./gradlew :iceberg-bom:publishToMavenLocal \
-            :iceberg-api:publishToMavenLocal \
-            :iceberg-core:publishToMavenLocal \
-            :iceberg-common:publishToMavenLocal \
-            :iceberg-bundled-guava:publishToMavenLocal
 
       - name: Gradle Build Apache Polaris
         env:
@@ -116,6 +98,5 @@ jobs:
 
       - name: Stop Gradle daemons
         run: |
-          $GITHUB_WORKSPACE/iceberg/gradlew --stop
           $GITHUB_WORKSPACE/polaris/gradlew --stop
           $GITHUB_WORKSPACE/authmgr/gradlew --stop

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@
 
 [versions]
 errorprone = "2.36.0"
-iceberg = "1.9.0-authmgr"
+iceberg = "1.9.0-SNAPSHOT"
 immutables = "2.10.1"
 mockserver = "5.15.0"
 slf4j = "2.0.16"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,6 +47,7 @@ dependencyResolutionManagement {
     mavenCentral()
     mavenLocal()
     gradlePluginPortal()
+    maven { url = uri("https://repository.apache.org/content/groups/public") }
   }
 }
 


### PR DESCRIPTION
Using the available snapshots simplifies CI. Once the 1.9.0 release is out, we can get rid of the Apache maven repo.