### PR TITLE
Impersonated token should never expire after the primary one

### DIFF
--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/token/AccessToken.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/token/AccessToken.java
@@ -25,6 +25,9 @@ public interface AccessToken extends Token {
   /** The type of the token issued, typically "Bearer". */
   String getTokenType();
 
+  @Override
+  AccessToken withExpirationTime(@Nullable Instant expirationTime);
+
   static AccessToken of(String payload) {
     return of(payload, "Bearer", null);
   }

--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/token/RefreshToken.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/token/RefreshToken.java
@@ -22,6 +22,9 @@ import java.time.Instant;
 @AuthManagerImmutable
 public interface RefreshToken extends Token {
 
+  @Override
+  RefreshToken withExpirationTime(@Nullable Instant expirationTime);
+
   static RefreshToken of(String payload, @Nullable Instant expirationTime) {
     return ImmutableRefreshToken.builder().payload(payload).expirationTime(expirationTime).build();
   }

--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/token/Token.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/token/Token.java
@@ -62,4 +62,7 @@ public interface Token {
     Instant exp = getResolvedExpirationTime();
     return exp != null && !exp.isAfter(when);
   }
+
+  /** Returns a new token with the same payload but a different expiration time. */
+  Token withExpirationTime(@Nullable Instant expirationTime);
 }

--- a/oauth2/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/ImpersonatingTokenExchangeFlowTest.java
+++ b/oauth2/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/ImpersonatingTokenExchangeFlowTest.java
@@ -16,16 +16,23 @@
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_EXPIRATION_TIME;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_LIFESPAN;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.NOW;
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_EXPIRATION_TIME;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokens;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
 import com.dremio.iceberg.authmgr.oauth2.token.RefreshToken;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.time.Duration;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ImpersonatingTokenExchangeFlowTest {
 
@@ -48,5 +55,38 @@ class ImpersonatingTokenExchangeFlowTest {
       Tokens tokens = flow.fetchNewTokens(currentTokens);
       assertTokens(tokens, "access_impersonated", "refresh_initial");
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void expirationTimes(Duration primaryLifespan, Duration secondaryLifespan, Duration expected) {
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .grantType(GrantType.AUTHORIZATION_CODE)
+                .impersonationEnabled(true)
+                .accessTokenLifespan(primaryLifespan)
+                .impersonationAccessTokenLifespan(secondaryLifespan)
+                .build();
+        Flow flow = env.newImpersonationFlow()) {
+      Tokens currentTokens =
+          Tokens.of(
+              AccessToken.of("access_initial", "Bearer", NOW.plus(primaryLifespan)),
+              RefreshToken.of("refresh_initial", REFRESH_TOKEN_EXPIRATION_TIME));
+      Tokens tokens = flow.fetchNewTokens(currentTokens);
+      assertThat(tokens.getAccessToken().getExpirationTime()).isEqualTo(NOW.plus(expected));
+    }
+  }
+
+  static Stream<Arguments> expirationTimes() {
+    return Stream.of(
+        Arguments.of(ACCESS_TOKEN_LIFESPAN, ACCESS_TOKEN_LIFESPAN, ACCESS_TOKEN_LIFESPAN),
+        Arguments.of(
+            ACCESS_TOKEN_LIFESPAN.minusSeconds(1),
+            ACCESS_TOKEN_LIFESPAN,
+            ACCESS_TOKEN_LIFESPAN.minusSeconds(1)),
+        Arguments.of(
+            ACCESS_TOKEN_LIFESPAN,
+            ACCESS_TOKEN_LIFESPAN.minusSeconds(1),
+            ACCESS_TOKEN_LIFESPAN.minusSeconds(1)));
   }
 }

--- a/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -391,6 +391,16 @@ public abstract class TestEnvironment implements AutoCloseable {
   }
 
   @Value.Default
+  public Duration getImpersonationAccessTokenLifespan() {
+    return getAccessTokenLifespan();
+  }
+
+  @Value.Default
+  public Duration getRefreshTokenLifespan() {
+    return TestConstants.REFRESH_TOKEN_LIFESPAN;
+  }
+
+  @Value.Default
   public ResourceOwnerConfig getResourceOwnerConfig() {
     return ResourceOwnerConfig.builder()
         .username(TestConstants.USERNAME)

--- a/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AbstractTokenEndpointExpectation.java
+++ b/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AbstractTokenEndpointExpectation.java
@@ -66,13 +66,15 @@ public abstract class AbstractTokenEndpointExpectation extends AbstractExpectati
     ImmutableTokenResponse.Builder responseBody =
         ImmutableTokenResponse.builder()
             .accessTokenPayload(accessToken)
-            .accessTokenExpiresInSeconds(TestConstants.ACCESS_TOKEN_EXPIRES_IN_SECONDS)
+            .accessTokenExpiresInSeconds(
+                (int) getTestEnvironment().getAccessTokenLifespan().toSeconds())
             .tokenType("bearer");
     if (getTestEnvironment().isReturnRefreshTokens()
         && getTestEnvironment().getGrantType() != GrantType.CLIENT_CREDENTIALS) {
       responseBody
           .refreshTokenPayload(refreshToken)
-          .refreshTokenExpiresInSeconds(TestConstants.REFRESH_TOKEN_EXPIRES_IN_SECONDS);
+          .refreshTokenExpiresInSeconds(
+              (int) getTestEnvironment().getRefreshTokenLifespan().toSeconds());
     }
     if (getTestEnvironment().getGrantType() == GrantType.TOKEN_EXCHANGE) {
       // included for completeness, but not used

--- a/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/ImpersonationTokenExchangeExpectation.java
+++ b/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/ImpersonationTokenExchangeExpectation.java
@@ -21,6 +21,7 @@ import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.CLIENT_ID2;
 import static com.dremio.iceberg.authmgr.oauth2.test.expectation.ExpectationUtils.getParameterBody;
 
 import com.dremio.iceberg.authmgr.oauth2.rest.ImmutableTokenExchangeRequest;
+import com.dremio.iceberg.authmgr.oauth2.rest.ImmutableTokenResponse;
 import com.dremio.iceberg.authmgr.oauth2.rest.PostFormRequest;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import java.net.URI;
@@ -65,5 +66,13 @@ public abstract class ImpersonationTokenExchangeExpectation extends InitialToken
         .resource(RESOURCE)
         .extraParameters(Map.of("impersonation", "true"))
         .build();
+  }
+
+  @Override
+  protected ImmutableTokenResponse.Builder tokenResponseBody(
+      String accessToken, String refreshToken) {
+    return super.tokenResponseBody(accessToken, refreshToken)
+        .accessTokenExpiresInSeconds(
+            (int) getTestEnvironment().getImpersonationAccessTokenLifespan().toSeconds());
   }
 }


### PR DESCRIPTION
Until now the impersonation flow implicitly assumed that the impersonated token would expire before the primary token, or at the same time.

This PR introduces a safeguard to check whether the assumption holds true, and if not, adjusts the impersonated token expiration time.