### PR TITLE
Fix incorrect handling of init sessions

### DIFF
--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Session.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Session.java
@@ -32,9 +32,13 @@ public class OAuth2Session implements AuthSession {
   private final OAuth2Agent agent;
 
   public OAuth2Session(
-      OAuth2AgentSpec spec, RESTClient restClient, ScheduledExecutorService executor) {
+      OAuth2AgentSpec spec, ScheduledExecutorService executor, RESTClient restClient) {
     this.spec = spec;
-    agent = new OAuth2Agent(spec, restClient, executor);
+    this.agent = new OAuth2Agent(spec, executor, restClient);
+  }
+
+  public void updateRestClient(RESTClient restClient) {
+    agent.updateRestClient(restClient);
   }
 
   public OAuth2AgentSpec getSpec() {

--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
@@ -58,12 +58,13 @@ public final class OAuth2Agent implements Closeable {
   private final ScheduledExecutorService executor;
   private final String name;
   private final Clock clock;
-  private final FlowContext context;
-  private final FlowContext impersonationContext;
 
   private final CompletableFuture<Void> used = new CompletableFuture<>();
   private final AtomicBoolean closing = new AtomicBoolean();
   private final AtomicBoolean sleeping = new AtomicBoolean();
+
+  private volatile FlowContext context;
+  private volatile FlowContext impersonationContext;
 
   private volatile CompletionStage<Tokens> currentTokensStage;
   private volatile ScheduledFuture<?> tokenRefreshFuture;
@@ -71,7 +72,7 @@ public final class OAuth2Agent implements Closeable {
   private volatile Instant lastWarn;
 
   public OAuth2Agent(
-      OAuth2AgentSpec spec, RESTClient restClient, ScheduledExecutorService executor) {
+      OAuth2AgentSpec spec, ScheduledExecutorService executor, RESTClient restClient) {
     this.spec = spec;
     this.executor = executor;
     name = spec.getRuntimeConfig().getAgentName();
@@ -99,6 +100,11 @@ public final class OAuth2Agent implements Closeable {
         .whenComplete((tokens, error) -> maybeScheduleTokensRenewal(tokens));
   }
 
+  public void updateRestClient(RESTClient restClient) {
+    context = FlowContextFactory.createFlowContext(spec, restClient);
+    impersonationContext = FlowContextFactory.createImpersonationFlowContext(spec, restClient);
+  }
+
   /** Authenticates the client and returns the current access token. */
   public AccessToken authenticate() {
     return doAuthenticate().getAccessToken();
@@ -106,7 +112,7 @@ public final class OAuth2Agent implements Closeable {
 
   Tokens doAuthenticate() {
     if (closing.get()) {
-      throw new IllegalStateException("Client is closing");
+      throw new IllegalStateException("Agent is closing");
     }
     LOGGER.debug("[{}] Authenticating with current token", name);
     used.complete(null);
@@ -215,11 +221,11 @@ public final class OAuth2Agent implements Closeable {
   private void maybeScheduleTokensRenewal(@Nullable Tokens currentTokens) {
     if (!spec.getTokenRefreshConfig().isEnabled()) {
       LOGGER.debug(
-          "[{}] Client is not configured to keep tokens refreshed, skipping token renewal", name);
+          "[{}] Agent is not configured to keep tokens refreshed, skipping token renewal", name);
       return;
     }
     if (closing.get()) {
-      LOGGER.debug("[{}] Not checking if token renewal is required, client is closing", name);
+      LOGGER.debug("[{}] Not checking if token renewal is required, agent is closing", name);
       return;
     }
     Instant now = clock.instant();
@@ -237,7 +243,7 @@ public final class OAuth2Agent implements Closeable {
 
   private void scheduleTokensRenewal(Duration delay) {
     if (closing.get()) {
-      LOGGER.debug("[{}] Not scheduling token renewal, client is closing", name);
+      LOGGER.debug("[{}] Not scheduling token renewal, agent is closing", name);
       return;
     }
     LOGGER.debug("[{}] Scheduling token refresh in {}", name, delay);
@@ -298,7 +304,7 @@ public final class OAuth2Agent implements Closeable {
   private void maybeSleep(boolean onFailedRenewalSchedule) {
     if (!spec.getTokenRefreshConfig().isEnabled()) {
       LOGGER.debug(
-          "[{}] Client is not configured to keep tokens refreshed, not entering sleep", name);
+          "[{}] Agent is not configured to keep tokens refreshed, not entering sleep", name);
       return;
     }
     if (onFailedRenewalSchedule) {
@@ -318,7 +324,7 @@ public final class OAuth2Agent implements Closeable {
 
   private void wakeUp(Instant now) {
     if (closing.get()) {
-      LOGGER.debug("[{}] Not waking up, client is closing", name);
+      LOGGER.debug("[{}] Not waking up, agent is closing", name);
       return;
     }
     LOGGER.debug("[{}] Waking up...", name);

--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
@@ -101,8 +101,10 @@ public final class OAuth2Agent implements Closeable {
   }
 
   public void updateRestClient(RESTClient restClient) {
-    context = FlowContextFactory.createFlowContext(spec, restClient);
-    impersonationContext = FlowContextFactory.createImpersonationFlowContext(spec, restClient);
+    FlowContext ctx = context;
+    FlowContext impersonationCtx = impersonationContext;
+    this.context = FlowContextFactory.withRestClient(ctx, restClient);
+    this.impersonationContext = FlowContextFactory.withRestClient(impersonationCtx, restClient);
   }
 
   /** Authenticates the client and returns the current access token. */

--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/BasicConfig.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/BasicConfig.java
@@ -200,10 +200,11 @@ public interface BasicConfig {
     } else if (getIssuerUrl().isEmpty() && getTokenEndpoint().isEmpty()) {
       LoggerFactory.getLogger(BasicConfig.class)
           .warn(
-              "The selected dialect is ICEBERG and the configuration does not specify a token endpoint nor an issuer URL: "
+              "The selected dialect is {} and the configuration does not specify a token endpoint nor an issuer URL: "
                   + "inferring that the token endpoint is internal to the REST catalog server. "
                   + "This automatic inference will be removed in a future release. "
                   + "Please define one of the following properties: '{}' or '{}'.",
+              Dialect.ICEBERG_REST,
               ISSUER_URL,
               TOKEN_ENDPOINT);
       basicConfig =

--- a/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowContextFactory.java
+++ b/oauth2/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowContextFactory.java
@@ -71,4 +71,16 @@ public final class FlowContextFactory {
         .runtimeConfig(spec.getRuntimeConfig())
         .build();
   }
+
+  @Nullable
+  public static FlowContext withRestClient(@Nullable FlowContext context, RESTClient restClient) {
+    if (context == null) {
+      return null;
+    }
+    return ImmutableFlowContext.builder()
+        .from(context)
+        .restClient(restClient)
+        .endpointProvider(EndpointProvider.builder().restClient(restClient).build())
+        .build();
+  }
 }

--- a/oauth2/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ManagerTest.java
+++ b/oauth2/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ManagerTest.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.HTTPHeaders.HTTPHeader;
 import org.apache.iceberg.rest.HTTPRequest;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
@@ -97,7 +98,7 @@ class OAuth2ManagerTest {
     }
 
     @Test
-    void catalogSessionWithInit() {
+    void catalogSessionWithInit() throws IOException {
       try (TestEnvironment env = TestEnvironment.builder().build();
           OAuth2Manager manager = new OAuth2Manager("test")) {
         Map<String, String> properties =
@@ -110,12 +111,14 @@ class OAuth2ManagerTest {
                 TestConstants.CLIENT_SECRET1,
                 Basic.SCOPE,
                 TestConstants.SCOPE1);
-        try (AuthSession session = manager.initSession(env.getHttpClient(), properties)) {
+        try (HTTPClient httpClient = env.newHttpClientBuilder(Map.of()).build();
+            AuthSession session = manager.initSession(httpClient, properties)) {
           HTTPRequest actual = session.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
               .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
         }
-        try (AuthSession session = manager.catalogSession(env.getHttpClient(), properties)) {
+        try (HTTPClient httpClient = env.newHttpClientBuilder(Map.of()).build();
+            AuthSession session = manager.catalogSession(httpClient, properties)) {
           HTTPRequest actual = session.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
               .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));

--- a/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -169,7 +169,7 @@ public abstract class TestEnvironment implements AutoCloseable {
     return newHttpClientBuilder(Map.of()).build();
   }
 
-  private HTTPClient.Builder newHttpClientBuilder(Map<String, String> properties) {
+  public HTTPClient.Builder newHttpClientBuilder(Map<String, String> properties) {
     return HTTPClient.builder(properties)
         .uri(getCatalogServerUrl())
         .withAuthSession(AuthSession.EMPTY);
@@ -596,7 +596,7 @@ public abstract class TestEnvironment implements AutoCloseable {
   }
 
   public OAuth2Agent newAgent() {
-    OAuth2Agent agent = new OAuth2Agent(getAgentSpec(), getHttpClient(), getExecutor());
+    OAuth2Agent agent = new OAuth2Agent(getAgentSpec(), getExecutor(), getHttpClient());
     getUser().setErrorListener(e -> agent.close());
     return agent;
   }


### PR DESCRIPTION
The catalog session was keeping the init `HTTPClient` which was causing errors when refreshing tokens since that `HTTPClient` is closed after the config endpoint is contacted.