### PR TITLE
feat(build): Add release workflow with JReleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: CI
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
               echo "Current version is not a SNAPSHOT version: $current_version"
               exit 1
           fi
+          echo TAG_NAME="authmgr-${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
 
       - name: Configure Git
         run: |
@@ -91,7 +92,7 @@ jobs:
           echo "${{ github.event.inputs.releaseVersion }}" > version.txt
           git add version.txt
           git commit -a -m "chore(release): release version ${{ github.event.inputs.releaseVersion }}"
-          git tag -f -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" "authmgr-${{ github.event.inputs.releaseVersion }}"
+          git tag -f -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" $TAG_NAME
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           java-version: 21
 
       - name: Build with Gradle
-        run: ./gradlew clean test publish assemble -x intTest --no-build-cache
+        run: ./gradlew build publish -x intTest
 
       - name: JReleaser full release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,16 @@ jobs:
           echo "${{ github.event.inputs.releaseVersion }}" > version.txt
           git add version.txt
           git commit -a -m "chore(release): release version ${{ github.event.inputs.releaseVersion }}"
-          git tag -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" $TAG_NAME
+          git tag -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" ${TAG_NAME}
+
+      - name: Push tag
+        run: |
+          if [[ "${{ github.event.inputs.dryRun }}" == "false" ]]; then
+            echo "Pushing tag ${TAG_NAME}."
+            git push origin ${TAG_NAME}
+          else
+            echo "Dry run enabled, not pushing tag."
+          fi
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -106,6 +115,7 @@ jobs:
       - name: JReleaser full release
         env:
           JRELEASER_DRY_RUN: ${{ github.event.inputs.dryRun }}
+          JRELEASER_TAG_NAME: ${TAG_NAME}
           JRELEASER_MAVENCENTRAL_STAGE: FULL
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.DEVBOT_CENTRAL_USERNAME }}
@@ -120,13 +130,13 @@ jobs:
           git add version.txt
           git commit -m "chore(release): set next development version to ${{ github.event.inputs.nextVersion }}"
 
-      - name: Push changes
+      - name: Push main branch
         run: |
           if [[ "${{ github.event.inputs.dryRun }}" == "false" ]]; then
-            echo "Pushing changes to main branch and tag."
-            git push origin $TAG_NAME main
+            echo "Pushing changes to main branch."
+            git push origin main
           else
-            echo "Dry run enabled, not pushing changes."
+            echo "Dry run enabled, not pushing to main branch."
           fi
 
       - name: Print JReleaser information

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.dryRun }}" == "false" ]]; then
             echo "Pushing changes to main branch and tag."
-            git push origin
+            git push origin $TAG_NAME main
           else
             echo "Dry run enabled, not pushing changes."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
         description: 'Release version (e.g., 0.1.0)'
         required: true
       nextVersion:
-        description: 'Next development version (e.g., 0.1.1-SNAPSHOT)'
+        description: 'Next development version (e.g., 0.1.1 - the suffix -SNAPSHOT will be added automatically)'
         required: true
       dryRun:
         description: 'Dry run (true or false)'
@@ -50,17 +50,20 @@ jobs:
       - name: Validate inputs
         run: |
           if [[ "${{ github.event.inputs.releaseVersion }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ && ! "${{ github.event.inputs.releaseVersion }}" =~ -SNAPSHOT$ ]]; then
-            echo "Valid release version: ${{ github.event.inputs.releaseVersion }}"
+            echo RELEASE_VERSION="${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
+            echo "Release version: $RELEASE_VERSION"
           else
             echo "Invalid release version format. Expected format: x.y.z or x.y.z-qualifier"
             exit 1
           fi
-          if [[ "${{ github.event.inputs.nextVersion }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
-            echo "Valid next development version: ${{ github.event.inputs.nextVersion }}"
+          if [[ "${{ github.event.inputs.nextVersion }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ && ! "${{ github.event.inputs.nextVersion }}" =~ -SNAPSHOT$ ]]; then
+            echo NEXT_VERSION="${{ github.event.inputs.nextVersion }}-SNAPSHOT" >> $GITHUB_ENV
+            echo "Next development version: $NEXT_VERSION"
           else
-            echo "Invalid next development version format. Expected format: x.y.z-SNAPSHOT"
+            echo "Invalid next development version format. Expected format: x.y.z or x.y.z-qualifier"
             exit 1
           fi
+          echo TAG_NAME="authmgr-${RELEASE_VERSION}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,7 +83,6 @@ jobs:
               echo "Current version is not a SNAPSHOT version: $current_version"
               exit 1
           fi
-          echo TAG_NAME="authmgr-${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
 
       - name: Configure Git
         run: |
@@ -89,10 +91,10 @@ jobs:
 
       - name: Update version for release
         run: |
-          echo "${{ github.event.inputs.releaseVersion }}" > version.txt
+          echo "${RELEASE_VERSION}" > version.txt
           git add version.txt
-          git commit -a -m "chore(release): release version ${{ github.event.inputs.releaseVersion }}"
-          git tag -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" ${TAG_NAME}
+          git commit -a -m "chore(release): release version ${RELEASE_VERSION}"
+          git tag -a -m "chore(release): tag version ${RELEASE_VERSION}" ${TAG_NAME}
 
       - name: Push tag
         run: |
@@ -126,9 +128,9 @@ jobs:
 
       - name: Update to next development version
         run: |
-          echo "${{ github.event.inputs.nextVersion }}" > version.txt
+          echo "${NEXT_VERSION}" > version.txt
           git add version.txt
-          git commit -m "chore(release): set next development version to ${{ github.event.inputs.nextVersion }}"
+          git commit -m "chore(release): set next development version to ${NEXT_VERSION}"
 
       - name: Push main branch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           echo "${{ github.event.inputs.releaseVersion }}" > version.txt
           git add version.txt
           git commit -a -m "chore(release): release version ${{ github.event.inputs.releaseVersion }}"
-          git tag -f -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" $TAG_NAME
+          git tag -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" $TAG_NAME
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+##
+## Copyright (C) 2025 Dremio Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (e.g., 0.1.0)'
+        required: true
+      nextVersion:
+        description: 'Next development version (e.g., 0.1.1-SNAPSHOT)'
+        required: true
+      dryRun:
+        description: 'Dry run (true or false)'
+        required: false
+        default: false
+        type: boolean
+
+# Required permissions for pushing to main branch and creating tags, issues and discussions
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  discussions: write
+
+jobs:
+  release:
+    name: Release version ${{ inputs.releaseVersion }}
+
+    # Only run in the original repository, not forks
+    if: github.repository == 'dremio/iceberg-auth-manager'
+    runs-on: ubuntu-latest
+    
+    steps:
+
+      - name: Validate inputs
+        run: |
+          if [[ "${{ github.event.inputs.releaseVersion }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ && ! "${{ github.event.inputs.releaseVersion }}" =~ -SNAPSHOT$ ]]; then
+            echo "Valid release version: ${{ github.event.inputs.releaseVersion }}"
+          else
+            echo "Invalid release version format. Expected format: x.y.z or x.y.z-qualifier"
+            exit 1
+          fi
+          if [[ "${{ github.event.inputs.nextVersion }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+            echo "Valid next development version: ${{ github.event.inputs.nextVersion }}"
+          else
+            echo "Invalid next development version format. Expected format: x.y.z-SNAPSHOT"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # Fetch all history for all branches and tags
+          ref: main # Checkout the main branch
+
+      - name: Verify current version
+        run: |
+          if [[ ! -f version.txt ]]; then
+            echo "version.txt file not found!"
+            exit 1
+          fi
+          current_version=$(cat version.txt)
+          if [[ ! "$current_version" =~ -SNAPSHOT$ ]]; then
+              echo "Current version is not a SNAPSHOT version: $current_version"
+              exit 1
+          fi
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "authmgr-release-workflow-noreply@dremio.com"
+          git config --global user.name "AuthManager Release Workflow [bot]"
+
+      - name: Update version for release
+        run: |
+          echo "${{ github.event.inputs.releaseVersion }}" > version.txt
+          git add version.txt
+          git commit -a -m "chore(release): release version ${{ github.event.inputs.releaseVersion }}"
+          git tag -f -a -m "chore(release): tag version ${{ github.event.inputs.releaseVersion }}" "authmgr-${{ github.event.inputs.releaseVersion }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Build with Gradle
+        run: ./gradlew clean test publish assemble -x intTest --no-build-cache
+
+      - name: JReleaser full release
+        env:
+          JRELEASER_DRY_RUN: ${{ github.event.inputs.dryRun }}
+          JRELEASER_MAVENCENTRAL_STAGE: FULL
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.DEVBOT_CENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.DEVBOT_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.DEVBOT_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.DEVBOT_GPG_PRIVATE_KEY }}
+        run: ./gradlew jreleaserFullRelease
+
+      - name: Update to next development version
+        run: |
+          echo "${{ github.event.inputs.nextVersion }}" > version.txt
+          git add version.txt
+          git commit -m "chore(release): set next development version to ${{ github.event.inputs.nextVersion }}"
+
+      - name: Push changes
+        run: |
+          if [[ "${{ github.event.inputs.dryRun }}" == "false" ]]; then
+            echo "Pushing changes to main branch and tag."
+            git push origin
+          else
+            echo "Dry run enabled, not pushing changes."
+          fi
+
+      - name: Print JReleaser information
+        if: always()
+        run: |
+          if [ -f build/jreleaser/output.properties ]; then
+            echo "JReleaser output properties:"
+            cat build/jreleaser/output.properties
+          else
+            echo "No JReleaser output properties found."
+          fi
+          if [ -f build/jreleaser/trace.log ]; then
+            echo "JReleaser logs:"
+            cat build/jreleaser/trace.log
+          else
+            echo "No JReleaser logs found."
+          fi

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
   implementation(baselibs.idea.ext)
   implementation(baselibs.shadow)
   implementation(baselibs.spotless)
+  implementation(baselibs.jreleaser)
 }

--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -113,7 +113,6 @@ jreleaser {
       repoOwner.set("dremio")
       name.set("iceberg-auth-manager")
       branch.set("main")
-      skipTag.set(true)
       tagName.set("authmgr-{{projectVersion}}")
       commitAuthor {
         name.set("{{projectNameCapitalized}} Release Workflow [bot]")

--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jreleaser.model.Active
+import org.jreleaser.model.api.common.Apply
+import org.jreleaser.model.api.deploy.maven.MavenCentralMavenDeployer
+import java.time.LocalDate
+
+plugins {
+  id("org.jreleaser")
+}
+
+jreleaser {
+
+  gitRootSearch.set(true)
+
+  project {
+    name.set("Dremio Iceberg AuthManager")
+    description.set("Dremio AuthManager for Apache Iceberg")
+    authors.set(listOf("Dremio"))
+    license.set("Apache-2.0")
+    links {
+      homepage.set("https://github.com/dremio/iceberg-auth-manager")
+      bugTracker = "https://github.com/dremio/iceberg-auth-manager/issues"
+    }
+    inceptionYear = "2025"
+    vendor = "Dremio"
+    copyright = "Copyright (c) ${LocalDate.now().year} Dremio"
+  }
+
+  files {
+    subprojects.forEach { project ->
+      glob {
+        pattern.set(project.layout.buildDirectory.dir("libs").get().asFile.absolutePath + "/**.jar")
+      }
+    }
+  }
+
+  signing {
+    active.set(Active.ALWAYS)
+    verify.set(false) // requires the GPG public key to be set up
+    armored.set(true)
+  }
+
+  hooks {
+    condition.set("'{{ Env.CI }}' == true")
+    script {
+      before {
+        filter {
+          includes.set(listOf("session"))
+        }
+        run.set("""
+        echo "### {{command}}" >> ${'$'}GITHUB_STEP_SUMMARY
+        echo "| Step | Outcome |" >> ${'$'}GITHUB_STEP_SUMMARY
+        echo "| ---- | ------- |" >> ${'$'}GITHUB_STEP_SUMMARY
+        """.trimIndent())
+      }
+      success {
+        filter {
+          excludes.set(listOf("session"))
+        }
+        run.set("""
+        echo "| {{event.name}} | :white_check_mark: |" >> ${'$'}GITHUB_STEP_SUMMARY
+        """.trimIndent())
+      }
+      success {
+        filter {
+          includes.set(listOf("session"))
+        }
+        run.set("""
+        echo "" >> ${'$'}GITHUB_STEP_SUMMARY
+        """.trimIndent())
+      }
+      failure {
+        filter {
+          excludes.set(listOf("session"))
+        }
+        run.set("""
+        echo "| {{event.name}} | :x: |" >> ${'$'}GITHUB_STEP_SUMMARY
+        """.trimIndent())
+      }
+      failure {
+        filter {
+          includes.set(listOf("session"))
+        }
+        run.set("""
+        echo "" >> ${'$'}GITHUB_STEP_SUMMARY
+        echo "### Failure" >> ${'$'}GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> ${'$'}GITHUB_STEP_SUMMARY
+        echo "{{event.stacktrace}}\`\`\`" >> ${'$'}GITHUB_STEP_SUMMARY
+        echo "" >> ${'$'}GITHUB_STEP_SUMMARY
+        """.trimIndent())
+      }
+    }
+  }
+
+  release {
+    github {
+      releaseName.set("{{projectNameCapitalized}} {{projectVersionNumber}}")
+      repoOwner.set("dremio")
+      name.set("iceberg-auth-manager")
+      branch.set("main")
+      skipTag.set(true)
+      tagName.set("authmgr-{{projectVersion}}")
+      commitAuthor {
+        name.set("{{projectNameCapitalized}} Release Workflow [bot]")
+        email.set("authmgr-release-workflow-noreply@dremio.com")
+      }
+      milestone {
+        close.set(true)
+        name.set("{{projectVersionNumber}}")
+      }
+      issues {
+        enabled.set(true)
+        comment.set("🎉 This issue has been resolved in version {{projectVersionNumber}} ([Release Notes]({{releaseNotesUrl}}))")
+        applyMilestone.set(Apply.ALWAYS)
+      }
+      discussionCategoryName.set("Announcements")
+      changelog {
+        links.set(true)
+        skipMergeCommits.set(true)
+        formatted.set(Active.ALWAYS)
+        preset.set("conventional-commits")
+        categoryTitleFormat.set("### {{categoryTitle}}")
+        content.set(
+          """
+          ## Try It Out
+          {{projectNameCapitalized}} is available as a Maven artifact from [Maven Central](https://central.sonatype.com/namespace/com.dremio.iceberg.authmgr).
+          You can also download the latest version from the [GitHub Releases page]({{repoUrl}}/releases).
+          ## Highlights
+          The full changelog can be found [here]({{repoUrl}}/compare/{{previousTagName}}...{{tagName}}).
+          {{changelogChanges}}
+          {{changelogContributors}}
+          """.trimIndent()
+        )
+        contributors {
+          format.set("- {{contributorName}}{{#contributorUsernameAsLink}} ({{.}}){{/contributorUsernameAsLink}}")
+        }
+        hide {
+          categories.set(listOf("test", "tasks", "build", "docs"))
+          contributors.set(listOf("[bot]", "renovate-bot"))
+        }
+      }
+    }
+  }
+
+  deploy {
+    maven {
+      mavenCentral {
+        create("sonatype")  {
+          stage.set(MavenCentralMavenDeployer.Stage.FULL)
+          active.set(Active.RELEASE_PRERELEASE)
+          url.set("https://central.sonatype.com/api/v1/publisher")
+          applyMavenCentralRules.set(true)
+          subprojects.forEach { project ->
+            stagingRepository(project.layout.buildDirectory.dir("staging-deploy").get().asFile.absolutePath)
+          }
+        }
+      }
+    }
+  }
+}

--- a/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
@@ -34,7 +34,7 @@ publishing {
 
                 licenses {
                     license {
-                        name = "The Apache License, Version 2.0"
+                        name = "Apache-2.0"
                         url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
                     }
                 }
@@ -51,8 +51,12 @@ publishing {
 
                 scm {
                     connection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
-                    developerConnection = "scm:git:ssh://github.com:dremio/iceberg-auth-manager.git"
+                    developerConnection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
                     url = "https://github.com/dremio/iceberg-auth-manager"
+                    val version = rootProject.file("version.txt").readText().trim()
+                    if (!version.endsWith("-SNAPSHOT")) {
+                        tag = "authmgr-$version"
+                    }
                 }
             }
 

--- a/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `maven-publish`
+}
+
+publishing {
+    publications {
+
+        // This publication is used by JReleaser
+        create<MavenPublication>("staging-maven") {
+
+            from(components["java"])
+
+            pom {
+                name = "Auth Manager for Apache Iceberg"
+                description = "Dremio AuthManager for Apache Iceberg is an OAuth2 manager for Apache Iceberg REST. It is a general-purpose implementation that is compatible with any Apache Iceberg REST catalog."
+                url.set("https://github.com/dremio/iceberg-auth-manager")
+                inceptionYear = "2025"
+
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = "dremio"
+                        name = "Dremio"
+                        email = "oss@dremio.com"
+                        organization = "Dremio Corporation"
+                        organizationUrl = "https://www.dremio.com"
+                    }
+                }
+
+                scm {
+                    connection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
+                    developerConnection = "scm:git:ssh://github.com:dremio/iceberg-auth-manager.git"
+                    url = "https://github.com/dremio/iceberg-auth-manager"
+                }
+            }
+
+            // Suppress test fixtures capability warnings
+            suppressPomMetadataWarningsFor("testFixturesApiElements")
+            suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
+        }
+    }
+    repositories {
+        maven {
+            name = "localStaging"
+            url = layout.buildDirectory.dir("staging-deploy").get().asFile.toURI()
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
   id("idea")
   id("eclipse")
   id("authmgr-root")
+  id("authmgr-jreleaser")
   alias(libs.plugins.rat)
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,17 @@ This project contains an implementation of Apache Iceberg's `AuthManager` API fo
 
 ## Installation
 
-To install the Dremio AuthManager for Apache Iceberg, you can follow the instructions in the
-[installation](./installation.md) section.
+Dremio Iceberg AuthManager is available as a Maven artifact from
+[Maven Central](https://central.sonatype.com/namespace/com.dremio.iceberg.authmgr).
+You can also download the latest version from the
+[GitHub Releases page](https://github.com/adutra/iceberg-auth-manager/releases).
+
+Follow the instructions in the [Installation](./installation.md) section to get started.
+
+## Usage
+
+To use the Dremio AuthManager for Apache Iceberg with Apache Spark, you can
+follow the instructions in the [Usage](usage.md) section.
 
 ## Configuration
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,48 +15,50 @@ limitations under the License.
 -->
 # Dremio AuthManager for Apache Iceberg - Installation
 
-## Download
+## Overview
 
-The Dremio AuthManager for Apache Iceberg is available as a jar which you can download from the
+The Dremio AuthManager for Apache Iceberg can be obtained from various sources, including
+Maven Central and GitHub Releases. You can choose the method that best fits your needs.
+
+### Maven Artifacts
+
+Maven artifacts are published to 
+[Maven Central](https://central.sonatype.com/namespace/com.dremio.iceberg.authmgr). 
+You can include them directly in your project:
+
+#### Maven Dependency
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>com.dremio.iceberg.authmgr</groupId>
+    <artifactId>authmgr-oauth2</artifactId>
+    <version>0.0.2</version>
+  </dependency>
+</dependencies>
+```
+
+#### Gradle Dependency
+
+```kotlin
+dependencies {
+  implementation("com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2")
+}
+```
+
+### Direct Download
+
+Alternatively, you can download pre-built jars directly from the
 [Releases page](https://github.com/dremio/iceberg-auth-manager/releases).
 
-You should choose the `runtime` jar, e.g. `authmgr-oauth2-x.y.z-runtime.jar`.
+When running a Spark Shell session, you should choose the `runtime` jar, 
+e.g. `authmgr-oauth2-x.y.z-runtime.jar`.
 
-## Prerequisites
+### Building from Source
 
-* Iceberg Core 1.9.0 or later is required.
-* Dremio AuthManager for Apache Iceberg requires Java 11 or later for runtime.
-* Dremio AuthManager for Apache Iceberg is meant to be used in conjunction with an Iceberg engine
-  runtime jar, e.g. `iceberg-spark-runtime-3.5_2.12` or `iceberg-flink-runtime-1.20`.
+You can build the code source and publish artifacts to your local Maven repository 
+(`~/.m2/repository`) using the following command:
 
-## Usage with Spark
-
-To use the Dremio AuthManager for Apache Iceberg with Spark, you need to add the jar to your Spark
-classpath. You can do this by adding the jar to the `--jars` option when starting Spark, or by
-adding it to the `spark.jars` configuration property in your Spark configuration file.
-
-For example, if you are using the `spark-shell`, you can start it with the following command:
-
-```shell
-spark-shell \
-  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0 \
-  --jars /path/to/authmgr-oauth2-x.y.z-runtime.jar
+```bash
+./gradlew clean build publishToMavenLocal
 ```
-
-Similarly, if you are using Spark SQL, you can start it with the following command:
-
-```shell
-spark-sql  \
-  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0 \
-  --jars /path/to/authmgr-oauth2-x.y.z-runtime.jar
-```
-
-You can also add the jar to your spark-defaults.conf file:
-
-```
-spark.jars /path/to/authmgr-oauth2-x.y.z-runtime.jar
-```
-
-Once the jar is added to the classpath, you can use the Dremio AuthManager for Apache Iceberg in
-your Spark applications. See the [configuration](./configuration.md) section for more details on how
-to configure the Dremio AuthManager for Apache Iceberg.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ You can include them directly in your project:
   <dependency>
     <groupId>com.dremio.iceberg.authmgr</groupId>
     <artifactId>authmgr-oauth2</artifactId>
-    <version>0.0.2</version>
+    <version>[REPLACE_WITH_VERSION]</version>
   </dependency>
 </dependencies>
 ```
@@ -42,7 +42,7 @@ You can include them directly in your project:
 
 ```kotlin
 dependencies {
-  implementation("com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2")
+  implementation("com.dremio.iceberg.authmgr:authmgr-oauth2:[REPLACE_WITH_VERSION]")
 }
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,20 +37,20 @@ If you are using the `spark-shell`, you can start it with the following command:
 
 ```shell
 spark-shell \
-  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:[REPLACE_WITH_VERSION]
 ```
 
 Similarly, if you are using Spark SQL, you can start it with the following command:
 
 ```shell
 spark-sql \
-  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:[REPLACE_WITH_VERSION]
 ```
 
 You can also add these configurations to your spark-defaults.conf file:
 
 ```
-spark.jars.packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2
+spark.jars.packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:[REPLACE_WITH_VERSION]
 ```
 
 ### Using Downloaded JAR

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,83 @@
+<!--
+Copyright (C) 2025 Dremio Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Dremio AuthManager for Apache Iceberg - Usage
+
+## Prerequisites
+
+* Iceberg Core 1.9.0 or later is required.
+* Dremio AuthManager for Apache Iceberg requires Java 11 or later for runtime.
+* Dremio AuthManager for Apache Iceberg is meant to be used in conjunction with an Iceberg engine
+  runtime jar, e.g. `iceberg-spark-runtime-3.5_2.12` or `iceberg-flink-runtime-1.20`.
+
+## Usage with Spark
+
+To use the Dremio AuthManager for Apache Iceberg with Spark, you can use either
+the Maven-published artifacts or a downloaded JAR.
+
+### Using Maven Artifacts
+
+The recommended way to use Dremio AuthManager with Spark is through the
+`--packages` option which will automatically download the artifacts from Maven
+Central.
+
+If you are using the `spark-shell`, you can start it with the following command:
+
+```shell
+spark-shell \
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2
+```
+
+Similarly, if you are using Spark SQL, you can start it with the following command:
+
+```shell
+spark-sql \
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2
+```
+
+You can also add these configurations to your spark-defaults.conf file:
+
+```
+spark.jars.packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0,com.dremio.iceberg.authmgr:authmgr-oauth2:0.0.2
+```
+
+### Using Downloaded JAR
+
+Alternatively, if you're using a downloaded JAR, you can add it to your Spark
+classpath using the `--jars` option:
+
+```shell
+spark-shell \
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0 \
+  --jars /path/to/authmgr-oauth2-x.y.z-runtime.jar
+```
+
+Similarly, for Spark SQL:
+
+```shell
+spark-sql \
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0 \
+  --jars /path/to/authmgr-oauth2-x.y.z-runtime.jar
+```
+
+Or in your spark-defaults.conf file:
+
+```
+spark.jars /path/to/authmgr-oauth2-x.y.z-runtime.jar
+```
+
+Once the jar is added to the classpath, you can use the Dremio AuthManager for Apache Iceberg in
+your Spark applications. See the [configuration](./configuration.md) section for more details on how
+to configure the Dremio AuthManager for Apache Iceberg.

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -20,5 +20,6 @@
 [libraries]
 errorprone = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version = "4.1.0" }
 idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext", version = "1.1.10" }
+jreleaser = { module = "org.jreleaser:jreleaser-gradle-plugin", version = "1.18.0" }
 shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "8.3.6" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.0.2" }

--- a/oauth2/build.gradle.kts
+++ b/oauth2/build.gradle.kts
@@ -18,11 +18,12 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   id("authmgr-java")
+  id("authmgr-maven")
   id("authmgr-shadow-jar")
 }
 
 dependencies {
-  implementation(enforcedPlatform(libs.iceberg.bom))
+  implementation(platform(libs.iceberg.bom))
   implementation("org.apache.iceberg:iceberg-api")
   implementation("org.apache.iceberg:iceberg-core")
 

--- a/tools/immutables/build.gradle.kts
+++ b/tools/immutables/build.gradle.kts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-plugins { id("authmgr-java") }
+plugins {
+  id("authmgr-java")
+  id("authmgr-maven")
+}
 
 val processor by configurations.creating
 


### PR DESCRIPTION
Fixes #12.

This change introduces the JReleaser Gradle plugin, which is used to deploy release artifacts to Maven Central and to generate a GitHub release.

It also introduces a new CI workflow to perform release tasks.

Note for reviewers: I thoroughly tested the release plugin & workflow on my own fork, using my own credentials and Sonatype account. I can say that everything works as expected there – which doesn't mean that they will work out of the box here. But at least I've sorted out the usual problems already.