### PR TITLE
fix(runtime-pom): use the right component

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
@@ -21,7 +21,11 @@ publishing {
 
     // This publication is used by JReleaser
     create<MavenPublication>("staging-maven") {
-      from(components["java"])
+      if (project.plugins.hasPlugin("com.gradleup.shadow")) {
+        from(components["shadow"])
+      } else {
+        from(components["java"])
+      }
 
       pom {
         name = "Auth Manager for Apache Iceberg"

--- a/oauth2/runtime/build.gradle.kts
+++ b/oauth2/runtime/build.gradle.kts
@@ -16,8 +16,8 @@
 
 plugins {
   id("authmgr-java")
-  id("authmgr-maven")
   id("authmgr-shadow-jar")
+  id("authmgr-maven")
 }
 
 // Create configurations to hold the core project's source and javadoc artifacts
@@ -76,3 +76,6 @@ tasks.named<Jar>("javadocJar") {
 
 // Skip the javadoc generation task as we'll copy from the core project
 tasks.withType<Javadoc> { enabled = false }
+
+// We're replacing the "original jar" with the uber-jar.
+tasks.named("jar") { enabled = false }


### PR DESCRIPTION
The authmgr-runtime pom includes a `<dependencies>` element containing a dependency to authmgr-core, which is wrong for the runtime-uber jar.

Fix is to use the `shadow` component instead of the `java` component in presence of the shadow plugin.