### PR TITLE
feat(oauth): Do not migrate legacy properties by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -396,9 +396,19 @@ For impersonation only. Extra claims to include in the client assertion JWT. Thi
 
 The distinctive name of the OAuth2 agent. Defaults to `iceberg-auth-manager`. This name is printed in all log messages and user prompts.
 
-### `rest.auth.oauth2.runtime.session-cache-timeout`
+## Manager Settings
+
+### `rest.auth.oauth2.manager.session-cache-timeout`
 
 The session cache timeout. Cached sessions will become eligible for eviction after this duration of inactivity. Defaults to `PT1H`. Must be a valid [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 
 This value is used for housekeeping; it does not mean that cached sessions will stop working after this time, but that the session cache will evict the session after this time of inactivity. If the context is used again, a new session will be created and cached.
+
+### `rest.auth.oauth2.manager.migrate-legacy-properties`
+
+Whether to migrate Iceberg OAuth2 legacy properties. Defaults to `false`.
+
+When enabled, the manager will automatically migrate legacy Iceberg OAuth2 properties to their new equivalents; e.g. it would map `oauth2-server-uri` to `rest.auth.oauth2.token-endpoint`.
+
+When disabled, legacy properties are ignored.
 

--- a/docs/dialects.md
+++ b/docs/dialects.md
@@ -25,14 +25,48 @@ Two "dialects" of OAuth2 are supported:
   `AuthManager` and exhibits some non-standard behavior.
 
 The dialect to use can be selected with the `rest.auth.oauth2.dialect` property. 
+
 By default, the dialect is set to `iceberg_rest` if either:
 
-* The `rest.auth.oauth2.token` property is set, or
-* The `rest.auth.oauth2.token-endpoint` property is set to a relative URL.
+* The `rest.auth.oauth2.token-endpoint` property is set to a relative URL, indicating that the
+  token endpoint is internal to the REST catalog server; or
+* The `rest.auth.oauth2.token` property is set, indicating the legacy behavior of using a
+  pre-defined access token; or
+* The `rest.auth.oauth2.client-secret` property is set and `rest.auth.oauth2.client-id` is not set 
+  (since only the Iceberg dialect supports client secrets without client IDs).
 
 In all other cases, the dialect is set to `standard`.
 
 ## Differences between "Standard" and "Iceberg" Dialects
+
+### Support for Legacy Configuration Properties
+
+Legacy configuration properties used by Iceberg REST's built-in OAuth2 `AuthManager` can be
+automatically migrated to their new counterparts by setting the
+`rest.auth.oauth2.manager.migrate-legacy-properties` property to `true` (the default is `false`).
+
+When migration is enabled, if any of these properties are set, a warning will be logged, and the new
+properties will be used instead. This feature is useful to enable progressive migration from the
+built-in OAuth2 `AuthManager` to this `AuthManager`.
+
+The legacy properties are listed below, along with their new counterparts:
+
+| Legacy Property         | New Property                                                      |
+|-------------------------|-------------------------------------------------------------------|
+| `oauth2-server-uri`     | `rest.auth.oauth2.token-endpoint`                                 |
+| `token`                 | `rest.auth.oauth2.token`                                          |
+| `credential`            | `rest.auth.oauth2.client-id` and `rest.auth.oauth2.client-secret` |
+| `scope`                 | `rest.auth.oauth2.scope`                                          |
+| `audience`              | `rest.auth.oauth2.token-exchange.audience`                        |
+| `resource`              | `rest.auth.oauth2.token-exchange.resource`                        |
+| `token-expires-in-ms`   | `rest.auth.oauth2.token-refresh.access-token-lifespan`            |
+| `token-refresh-enabled` | `rest.auth.oauth2.token-refresh.enabled`                          |
+
+When migration is disabled, the legacy properties are ignored.
+
+> [!WARNING]
+> Legacy properties migration is known to have issues with request signing. It is recommended to
+> disable automatic migration in this case, and to manually migrate to the new properties instead.
 
 ### Supported Grant Types
 

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Properties.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Properties.java
@@ -627,6 +627,11 @@ public final class OAuth2Properties {
     public static final String AGENT_NAME = Runtime.PREFIX + "agent-name";
 
     public static final String DEFAULT_AGENT_NAME = "iceberg-auth-manager";
+  }
+
+  public static final class Manager {
+
+    public static final String PREFIX = OAuth2Properties.PREFIX + "manager.";
 
     /**
      * The session cache timeout. Cached sessions will become eligible for eviction after this
@@ -640,6 +645,18 @@ public final class OAuth2Properties {
     public static final String SESSION_CACHE_TIMEOUT = Runtime.PREFIX + "session-cache-timeout";
 
     public static final String DEFAULT_SESSION_CACHE_TIMEOUT = "PT1H";
+
+    /**
+     * Whether to migrate Iceberg OAuth2 legacy properties. Defaults to {@code false}.
+     *
+     * <p>When enabled, the manager will automatically migrate legacy Iceberg OAuth2 properties to
+     * their new equivalents; e.g. it would map {@code oauth2-server-uri} to {@link
+     * Basic#TOKEN_ENDPOINT}.
+     *
+     * <p>When disabled, legacy properties are ignored.
+     */
+    public static final String MIGRATE_LEGACY_PROPERTIES =
+        Runtime.PREFIX + "migrate-legacy-properties";
   }
 
   private OAuth2Properties() {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/compat/PropertiesSanitizer.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/compat/PropertiesSanitizer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.compat;
+
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Properties;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class PropertiesSanitizer {
+
+  private static final Set<String> CONTEXT_DENY_LIST = Set.of(OAuth2Properties.Basic.DIALECT);
+
+  private static final Set<String> TABLE_DENY_LIST =
+      Set.of(
+          OAuth2Properties.Basic.CLIENT_ID,
+          OAuth2Properties.Basic.CLIENT_SECRET,
+          OAuth2Properties.Basic.DIALECT,
+          OAuth2Properties.ResourceOwner.USERNAME,
+          OAuth2Properties.ResourceOwner.PASSWORD,
+          OAuth2Properties.Impersonation.CLIENT_ID,
+          OAuth2Properties.Impersonation.CLIENT_SECRET,
+          OAuth2Properties.TokenExchange.SUBJECT_TOKEN,
+          OAuth2Properties.TokenExchange.ACTOR_TOKEN,
+          OAuth2Properties.ClientAssertion.ALGORITHM,
+          OAuth2Properties.ClientAssertion.PRIVATE_KEY,
+          OAuth2Properties.ImpersonationClientAssertion.ALGORITHM,
+          OAuth2Properties.ImpersonationClientAssertion.PRIVATE_KEY);
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesSanitizer.class);
+
+  /** Sanitizes context properties received from the catalog's session context. */
+  public static Map<String, String> sanitizeContextProperties(Map<String, String> properties) {
+    properties = new HashMap<>(properties);
+    for (Iterator<String> iterator = properties.keySet().iterator(); iterator.hasNext(); ) {
+      String key = iterator.next();
+      if (CONTEXT_DENY_LIST.contains(key)) {
+        LOGGER.warn(
+            "Ignoring property '{}': this property is not allowed in a session context.", key);
+        iterator.remove();
+      }
+    }
+    return properties;
+  }
+
+  /** Sanitizes table properties received from the server. */
+  public static Map<String, String> sanitizeTableProperties(Map<String, String> properties) {
+    properties = new HashMap<>(properties);
+    for (Iterator<String> iterator = properties.keySet().iterator(); iterator.hasNext(); ) {
+      String key = iterator.next();
+      if (TABLE_DENY_LIST.contains(key)) {
+        LOGGER.warn(
+            "Ignoring property '{}': this property is not allowed to be vended by catalog servers.",
+            key);
+        iterator.remove();
+      }
+      if (key.equals(OAuth2Properties.Basic.TOKEN)) {
+        LOGGER.warn(
+            "Detected property '{}' in a server response. "
+                + "Vending OAuth2 tokens will be disallowed in a future release; "
+                + "catalog servers should vend OAuth2 scopes instead.",
+            key);
+      }
+    }
+    return properties;
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ManagerTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ManagerTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.never;
 
 import com.dremio.iceberg.authmgr.oauth2.OAuth2Properties.Basic;
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Properties.Manager;
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentSpec;
 import com.dremio.iceberg.authmgr.oauth2.cache.AuthSessionCache;
 import com.dremio.iceberg.authmgr.oauth2.config.Dialect;
@@ -257,7 +258,9 @@ class OAuth2ManagerTest {
                 Basic.CLIENT_SECRET,
                 TestConstants.CLIENT_SECRET1,
                 Basic.SCOPE,
-                TestConstants.SCOPE1);
+                TestConstants.SCOPE1,
+                Manager.MIGRATE_LEGACY_PROPERTIES,
+                "true");
         SessionContext context =
             new SessionContext(
                 "test",
@@ -396,7 +399,9 @@ class OAuth2ManagerTest {
                 Basic.CLIENT_ID,
                 TestConstants.CLIENT_ID1,
                 Basic.CLIENT_SECRET,
-                TestConstants.CLIENT_SECRET1);
+                TestConstants.CLIENT_SECRET1,
+                Manager.MIGRATE_LEGACY_PROPERTIES,
+                "true");
         Map<String, String> tableProperties =
             Map.of(org.apache.iceberg.rest.auth.OAuth2Properties.SCOPE, TestConstants.SCOPE1);
         try (AuthSession catalogSession =
@@ -423,8 +428,7 @@ class OAuth2ManagerTest {
                 TestConstants.CLIENT_ID1,
                 Basic.CLIENT_SECRET,
                 TestConstants.CLIENT_SECRET1);
-        Map<String, String> tableProperties =
-            Map.of(org.apache.iceberg.rest.auth.OAuth2Properties.SCOPE, TestConstants.SCOPE2);
+        Map<String, String> tableProperties = Map.of(Basic.SCOPE, TestConstants.SCOPE2);
         try (AuthSession catalogSession =
                 manager.catalogSession(env.getHttpClient(), catalogProperties);
             AuthSession tableSession1 =
@@ -485,8 +489,7 @@ class OAuth2ManagerTest {
                     TestConstants.CLIENT_SECRET2),
                 Map.of(Basic.SCOPE, TestConstants.SCOPE2));
 
-        Map<String, String> tableProperties =
-            Map.of(org.apache.iceberg.rest.auth.OAuth2Properties.SCOPE, TestConstants.SCOPE2);
+        Map<String, String> tableProperties = Map.of(Basic.SCOPE, TestConstants.SCOPE2);
 
         try (AuthSession initSession =
                 Mockito.spy(manager.initSession(env.getHttpClient(), catalogProperties));


### PR DESCRIPTION
Fixes #72.

This change makes legacy migration an opt-in feature. This change should allow request signing to work out of the box, since the issue was related to the automatic migration of hard-coded legacy properties in Iceberg's `S3V4RestSignerClient`.

This change also splits `IcebergCompatibility` into two components, one for properties migration, the other for sanitizing properties, with no functional difference.