### PR TITLE
feat(ci): Add integration tests for request signing

### DIFF
--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/container/NessieContainer.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/container/NessieContainer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.test.container;
+
+import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+/** A test container for Nessie servers. */
+public class NessieContainer extends GenericContainer<NessieContainer> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NessieContainer.class);
+
+  private URI baseUri;
+
+  @SuppressWarnings("resource")
+  public NessieContainer() {
+    super("ghcr.io/projectnessie/nessie:0.104.1");
+    withLogConsumer(new Slf4jLogConsumer(LOGGER));
+    withExposedPorts(19120, 9000);
+    withNetworkAliases("nessie");
+    waitingFor(Wait.forHttp("/q/health/ready").forPort(9000));
+    withEnv("nessie.version.store.type", "IN_MEMORY");
+    withEnv("quarkus.log.level", getRootLoggerLevel());
+    withEnv("quarkus.log.console.level", getRootLoggerLevel());
+    withEnv("quarkus.log.category.\"org.projectnessie\".level", getNessieLoggerLevel());
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    baseUri = URI.create("http://localhost:" + getMappedPort(19120));
+  }
+
+  /** Returns the Iceberg REST API endpoint URI. */
+  public URI getIcebergRestApiEndpoint() {
+    return baseUri.resolve("/iceberg");
+  }
+
+  private static String getRootLoggerLevel() {
+    return LOGGER.isInfoEnabled() ? "INFO" : LOGGER.isWarnEnabled() ? "WARN" : "ERROR";
+  }
+
+  private static String getNessieLoggerLevel() {
+    return LOGGER.isDebugEnabled() ? "DEBUG" : getRootLoggerLevel();
+  }
+}

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkNessieS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkNessieS3ITBase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.test.spark;
+
+import com.dremio.iceberg.authmgr.oauth2.test.container.NessieContainer;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.Network;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class SparkNessieS3ITBase extends SparkS3ITBase {
+
+  protected volatile NessieContainer nessie;
+
+  @Override
+  protected CompletableFuture<Void> startAllContainers(Network network) {
+    return CompletableFuture.allOf(
+        super.startAllContainers(network),
+        createNessieContainer(network)
+            .thenCompose(
+                container -> {
+                  nessie = container;
+                  return CompletableFuture.runAsync(container::start);
+                })
+            .thenCompose(v -> fetchNewToken()));
+  }
+
+  protected abstract CompletableFuture<NessieContainer> createNessieContainer(Network network);
+
+  protected abstract CompletableFuture<String> fetchNewToken();
+
+  @Override
+  protected URI catalogApiEndpoint() {
+    return nessie.getIcebergRestApiEndpoint();
+  }
+
+  @AfterAll
+  @Override
+  public void stopAllContainers() {
+    var nessie = this.nessie;
+    try (nessie) {
+      super.stopAllContainers();
+    }
+  }
+}

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisS3IT.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisS3IT.java
@@ -49,8 +49,8 @@ public class SparkPolarisS3IT extends SparkPolarisS3ITBase {
   protected Map<String, Object> sparkConfig(Path tempDir) {
     return ImmutableMap.<String, Object>builder()
         .putAll(super.sparkConfig(tempDir))
-        .put("spark.sql.catalog.polaris.rest.auth.oauth2.dialect", "iceberg_rest")
-        .put("spark.sql.catalog.polaris.rest.auth.oauth2.scope", "PRINCIPAL_ROLE:ALL")
+        .put("spark.sql.catalog.test.rest.auth.oauth2.dialect", "iceberg_rest")
+        .put("spark.sql.catalog.test.rest.auth.oauth2.scope", "PRINCIPAL_ROLE:ALL")
         .build();
   }
 }

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisS3ITBase.java
@@ -15,46 +15,26 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.test.spark;
 
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.CLIENT_ID1;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.CLIENT_SECRET1;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.WAREHOUSE;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
-import com.dremio.iceberg.authmgr.oauth2.OAuth2Manager;
 import com.dremio.iceberg.authmgr.oauth2.test.container.PolarisContainer;
 import com.google.common.collect.ImmutableMap;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.Network;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class SparkPolarisS3ITBase {
+public abstract class SparkPolarisS3ITBase extends SparkS3ITBase {
 
-  protected S3MockContainer s3;
   protected volatile PolarisContainer polaris;
-  protected SparkSession spark;
 
-  @BeforeAll
-  public void setup(@TempDir Path tempDir) {
-    var network = Network.newNetwork();
-    startAllContainers(network).join();
-    Map<String, Object> sparkConfig = sparkConfig(tempDir);
-    spark = SparkSession.builder().master("local[1]").config(sparkConfig).getOrCreate();
-  }
-
+  @Override
   protected CompletableFuture<Void> startAllContainers(Network network) {
-    s3 = createS3Container(network);
     return CompletableFuture.allOf(
-        CompletableFuture.runAsync(this.s3::start),
+        super.startAllContainers(network),
         createPolarisContainer(network)
             .thenCompose(
                 container -> {
@@ -65,17 +45,14 @@ public abstract class SparkPolarisS3ITBase {
             .thenAccept(this::createPolarisCatalog));
   }
 
-  @SuppressWarnings("resource")
-  protected S3MockContainer createS3Container(Network network) {
-    return new S3MockContainer("3.11.0")
-        .withInitialBuckets("test-bucket")
-        .withNetwork(network)
-        .withNetworkAliases("s3");
-  }
-
   protected abstract CompletableFuture<PolarisContainer> createPolarisContainer(Network network);
 
   protected abstract CompletableFuture<String> fetchNewToken();
+
+  @Override
+  protected URI catalogApiEndpoint() {
+    return polaris.getCatalogApiEndpoint();
+  }
 
   protected void createPolarisCatalog(String token) {
     polaris.createCatalog(
@@ -104,50 +81,20 @@ public abstract class SparkPolarisS3ITBase {
             List.of("s3://test-bucket/path/to/data")));
   }
 
+  @Override
   protected Map<String, Object> sparkConfig(Path tempDir) {
     return ImmutableMap.<String, Object>builder()
-        .put(
-            "spark.sql.extensions",
-            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
-        .put("spark.ui.showConsoleProgress", "false")
-        .put("spark.ui.enabled", "false")
-        .put("spark.sql.warehouse.dir", tempDir.toString())
-        .put("spark.sql.catalog.polaris", "org.apache.iceberg.spark.SparkCatalog")
-        .put("spark.sql.catalog.polaris.type", "rest")
-        .put("spark.sql.catalog.polaris.uri", polaris.getCatalogApiEndpoint().toString())
-        .put("spark.sql.catalog.polaris.warehouse", WAREHOUSE)
-        .put("spark.sql.catalog.polaris.header.Polaris-Realm", "POLARIS")
-        .put("spark.sql.catalog.polaris.header.Accept-Encoding", "none") // for debugging
-        .put("spark.sql.catalog.polaris.s3.path-style-access", "true")
-        .put("spark.sql.catalog.polaris.s3.endpoint", s3.getHttpEndpoint())
-        .put("spark.sql.catalog.polaris.rest.auth.type", OAuth2Manager.class.getName())
-        .put("spark.sql.catalog.polaris.rest.auth.oauth2.client-id", CLIENT_ID1)
-        .put("spark.sql.catalog.polaris.rest.auth.oauth2.client-secret", CLIENT_SECRET1)
+        .putAll(super.sparkConfig(tempDir))
+        .put("spark.sql.catalog.test.header.Polaris-Realm", "POLARIS")
         .build();
   }
 
-  @Test
-  public void smokeTest() {
-    spark.sql("USE polaris");
-    long namespaceCount = spark.sql("SHOW NAMESPACES").count();
-    assertThat(namespaceCount).isEqualTo(0L);
-    spark.sql("CREATE NAMESPACE ns1");
-    spark.sql("USE ns1");
-    spark.sql("CREATE TABLE tb1 (col1 integer, col2 string)");
-    spark.sql("INSERT INTO tb1 VALUES (1, 'a'), (2, 'b'), (3, 'c')");
-    long recordCount = spark.sql("SELECT * FROM tb1").count();
-    assertThat(recordCount).isEqualTo(3);
-  }
-
   @AfterAll
+  @Override
   public void stopAllContainers() {
     var polaris = this.polaris;
-    var s3 = this.s3;
-    try (polaris;
-        s3) {
-      if (spark != null) {
-        spark.close();
-      }
+    try (polaris) {
+      super.stopAllContainers();
     }
   }
 }

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkS3ITBase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.test.spark;
+
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.CLIENT_ID1;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.CLIENT_SECRET1;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.WAREHOUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Manager;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.Network;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class SparkS3ITBase {
+
+  protected S3MockContainer s3;
+  protected SparkSession spark;
+
+  @BeforeAll
+  public void setup(@TempDir Path tempDir) {
+    var network = Network.newNetwork();
+    startAllContainers(network).join();
+    Map<String, Object> sparkConfig = sparkConfig(tempDir);
+    spark = SparkSession.builder().master("local[1]").config(sparkConfig).getOrCreate();
+  }
+
+  protected abstract URI catalogApiEndpoint();
+
+  protected CompletableFuture<Void> startAllContainers(Network network) {
+    s3 = createS3Container(network);
+    return CompletableFuture.allOf(CompletableFuture.runAsync(this.s3::start));
+  }
+
+  @SuppressWarnings("resource")
+  protected S3MockContainer createS3Container(Network network) {
+    return new S3MockContainer("3.11.0")
+        .withInitialBuckets("test-bucket")
+        .withNetwork(network)
+        .withNetworkAliases("s3");
+  }
+
+  protected Map<String, Object> sparkConfig(Path tempDir) {
+    return ImmutableMap.<String, Object>builder()
+        .put(
+            "spark.sql.extensions",
+            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+        .put("spark.ui.showConsoleProgress", "false")
+        .put("spark.ui.enabled", "false")
+        .put("spark.sql.warehouse.dir", tempDir.toString())
+        .put("spark.sql.catalog.test", "org.apache.iceberg.spark.SparkCatalog")
+        .put("spark.sql.catalog.test.type", "rest")
+        .put("spark.sql.catalog.test.uri", catalogApiEndpoint().toString())
+        .put("spark.sql.catalog.test.warehouse", WAREHOUSE)
+        .put("spark.sql.catalog.test.header.Accept-Encoding", "none") // for debugging
+        .put("spark.sql.catalog.test.s3.path-style-access", "true")
+        .put("spark.sql.catalog.test.s3.endpoint", s3.getHttpEndpoint())
+        .put("spark.sql.catalog.test.rest.auth.type", OAuth2Manager.class.getName())
+        .put("spark.sql.catalog.test.rest.auth.oauth2.client-id", CLIENT_ID1)
+        .put("spark.sql.catalog.test.rest.auth.oauth2.client-secret", CLIENT_SECRET1)
+        .build();
+  }
+
+  @Test
+  public void smokeTest() {
+    spark.sql("USE test");
+    long namespaceCount = spark.sql("SHOW NAMESPACES").count();
+    assertThat(namespaceCount).isEqualTo(0L);
+    spark.sql("CREATE NAMESPACE ns1");
+    spark.sql("USE ns1");
+    spark.sql("CREATE TABLE tb1 (col1 integer, col2 string)");
+    spark.sql("INSERT INTO tb1 VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    long recordCount = spark.sql("SELECT * FROM tb1").count();
+    assertThat(recordCount).isEqualTo(3);
+  }
+
+  @AfterAll
+  public void stopAllContainers() {
+    var s3 = this.s3;
+    try (s3) {
+      if (spark != null) {
+        spark.close();
+      }
+    }
+  }
+}

--- a/oauth2/runtime-spark-tests/src/intTest/resources/logback-test.xml
+++ b/oauth2/runtime-spark-tests/src/intTest/resources/logback-test.xml
@@ -39,6 +39,8 @@
   <logger name="com.dremio.iceberg.authmgr.oauth2.test.container.KeycloakContainer" level="WARN"/>
   <!-- Polaris container logs -->
   <logger name="com.dremio.iceberg.authmgr.oauth2.test.container.PolarisContainer" level="WARN"/>
+  <!-- Nessie container logs -->
+  <logger name="com.dremio.iceberg.authmgr.oauth2.test.container.NessieContainer" level="WARN"/>
   <!-- creates duplicated container logs -->
   <logger name="tc" level="OFF"/>
 </configuration>


### PR DESCRIPTION
This change adds a NessieContainer, then uses that container to add integration tests with Spark, Nessie and Keycloak, in order to exercise request signing.