### PR TITLE
fix(ci): Temporarily use linux/arm images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # TODO: revert this image to ubuntu-latest when Polaris Docker images are available for linux/amd64
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
 


### PR DESCRIPTION
The Polaris Docker image only exists for linux/arm atm.