### PR TITLE
fix(oauth): Fix token exchange tests

### DIFF
--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentTest.java
@@ -285,6 +285,7 @@ class OAuth2AgentTest {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.TOKEN_EXCHANGE)
+                .subjectToken(null)
                 .subjectGrantType(grantType)
                 .privateClient(privateClient)
                 .returnRefreshTokens(returnRefreshTokens)

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
@@ -73,7 +73,10 @@ class TokenExchangeFlowTest {
                 .grantType(GrantType.TOKEN_EXCHANGE)
                 .privateClient(privateClient)
                 .returnRefreshTokens(returnRefreshTokens)
+                .subjectToken(null)
                 .subjectGrantType(grantType)
+                .actorToken(null)
+                .actorGrantType(grantType)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestConstants.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestConstants.java
@@ -79,7 +79,7 @@ public class TestConstants {
   public static final String AUDIENCE = "audience";
 
   public static final URI SUBJECT_TOKEN_TYPE = TypedToken.URN_ACCESS_TOKEN;
-  public static final URI ACTOR_TOKEN_TYPE = TypedToken.URN_ID_TOKEN;
+  public static final URI ACTOR_TOKEN_TYPE = TypedToken.URN_ACCESS_TOKEN;
   public static final URI REQUESTED_TOKEN_TYPE = TypedToken.URN_ACCESS_TOKEN;
   public static final URI RESOURCE = URI.create("urn:authmgr:test:resource");
 

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AuthorizationCodeExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AuthorizationCodeExpectation.java
@@ -92,7 +92,7 @@ public abstract class AuthorizationCodeExpectation extends InitialTokenFetchExpe
             .withQueryStringParameter("client_id", String.format("(%s|%s)", CLIENT_ID1, CLIENT_ID2))
             .withQueryStringParameter("scope", String.format("(%s|%s)", SCOPE1, SCOPE2))
             .withQueryStringParameter(
-                "redirect_uri", "http://localhost:\\d+/iceberg-auth-manager-\\w+/auth")
+                "redirect_uri", "http://localhost:\\d+/iceberg-auth-manager-\\w+(-\\w+)?/auth")
             .withQueryStringParameter("state", "\\w+");
     if (getTestEnvironment().isPkceEnabled()) {
       request.withQueryStringParameter("code_challenge", "[a-zA-Z0-9-._~]+");


### PR DESCRIPTION
Some tests were supposed to exercise "dynamic" subject and actor tokens, but due to misconfigurations, they weren't.