### PR TITLE
feat(ci): Split jobs & use temporary multi-platform Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@ on:
     branches: [ "main" ]
 
 jobs:
+
   build:
 
-    # TODO: revert this image to ubuntu-latest when Polaris Docker images are available for linux/amd64
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
+    name: Build & Publish
     permissions:
       contents: read
 
@@ -56,24 +57,17 @@ jobs:
           # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
           validate-wrappers: false
 
-      - name: Gradle Build Project Core & Runtime
+      - name: Gradle Build & Publish
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          cd $GITHUB_WORKSPACE/authmgr
-          ./gradlew --continue --scan :authmgr-oauth2-core:build :authmgr-oauth2-runtime:build --info --stacktrace
+          ./gradlew --continue --scan build publish -x intTest
 
-      - name: Gradle Build Project Spark Tests
+      - name: Gradle OAuth2 Core Integration Tests
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          cd $GITHUB_WORKSPACE/authmgr
-          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:build --info --stacktrace
-
-      - name: Gradle Build Project Flink Tests
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:build --info --stacktrace
+          ./gradlew --continue --scan :authmgr-oauth2-core:intTest -PexcludeTags=long
 
       - name: Gradle Check Generated Docs
         env:
@@ -85,6 +79,129 @@ jobs:
             echo "Generated documentation does not match existing documentation. Please run './gradlew :authmgr-docs-generator:generateDocs' and commit the changes."
             exit 1
           fi
+
+      - name: Archive Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: upload-test-artifacts
+          path: |
+            **/build/test-results/**
+
+  long-tests:
+
+    runs-on: ubuntu-latest
+    name: Long Running Tests
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
+          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
+          validate-wrappers: false
+
+      - name: Gradle Run Long Tests
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          ./gradlew --continue --scan :authmgr-oauth2-core:intTest -PincludeTags=long -Dauthmgr.it.long.total=PT1M
+
+      - name: Archive Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: upload-test-artifacts
+          path: |
+            **/build/test-results/**
+
+  spark-tests:
+
+    runs-on: ubuntu-latest
+    name: Spark Runtime Tests
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
+          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
+          validate-wrappers: false
+
+      - name: Gradle Run Spark Tests
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          cd $GITHUB_WORKSPACE/authmgr
+          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:intTest
+
+      - name: Archive Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: upload-test-artifacts
+          path: |
+            **/build/test-results/**
+
+  flink-tests:
+
+    runs-on: ubuntu-latest
+    name: Flink Runtime Tests
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
+          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
+          validate-wrappers: false
+
+      - name: Gradle Build Project Flink Tests
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:intTest
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,24 @@ jobs:
           # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
           validate-wrappers: false
 
-      - name: Gradle Build Project
+      - name: Gradle Build Project Core & Runtime
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: ./gradlew --continue --scan build publish
+        run: |
+          cd $GITHUB_WORKSPACE/authmgr
+          ./gradlew --continue --scan :authmgr-oauth2-core:build :authmgr-oauth2-runtime:build --info --stacktrace
+
+      - name: Gradle Build Project Spark Tests
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          cd $GITHUB_WORKSPACE/authmgr
+          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:build --info --stacktrace
+
+      - name: Gradle Build Project Flink Tests
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:build --info --stacktrace
 
       - name: Gradle Check Generated Docs
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,20 +58,14 @@ jobs:
           validate-wrappers: false
 
       - name: Gradle Build & Publish
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           ./gradlew --continue --scan build publish -x intTest
 
       - name: Gradle OAuth2 Core Integration Tests
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           ./gradlew --continue --scan :authmgr-oauth2-core:intTest -PexcludeTags=long
 
       - name: Gradle Check Generated Docs
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           ./gradlew --no-scan :authmgr-docs-generator:generateDocs
           git diff --exit-code docs/configuration.md
@@ -106,18 +100,12 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
-          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
           validate-wrappers: false
 
       - name: Gradle Run Long Tests
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           ./gradlew --continue --scan :authmgr-oauth2-core:intTest -PincludeTags=long -Dauthmgr.it.long.total=PT1M
 
@@ -147,20 +135,18 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
-          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
           validate-wrappers: false
 
-      - name: Gradle Run Spark & Flink Tests
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
+      - name: Gradle Run Spark Tests
         run: |
-          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:intTest :authmgr-oauth2-runtime-flink-tests:intTest
+          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:intTest
+
+      - name: Gradle Run Flink Tests
+        run: |
+          ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:intTest
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: upload-test-artifacts
+          name: build-test-results
           path: |
             **/build/test-results/**
 
@@ -125,7 +125,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: upload-test-artifacts
+          name: long-tests-results
           path: |
             **/build/test-results/**
 
@@ -160,14 +160,13 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          cd $GITHUB_WORKSPACE/authmgr
           ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:intTest
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: upload-test-artifacts
+          name: spark-tests-results
           path: |
             **/build/test-results/**
 
@@ -201,12 +200,13 @@ jobs:
       - name: Gradle Build Project Flink Tests
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:intTest
+        run: |
+          ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:intTest
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: upload-test-artifacts
+          name: flink-tests-results
           path: |
             **/build/test-results/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,10 @@ jobs:
           path: |
             **/build/test-results/**
 
-  spark-tests:
+  runtime-tests:
 
     runs-on: ubuntu-latest
-    name: Spark Runtime Tests
+    name: Spark & Flink Tests
     permissions:
       contents: read
 
@@ -156,57 +156,16 @@ jobs:
           # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
           validate-wrappers: false
 
-      - name: Gradle Run Spark Tests
+      - name: Gradle Run Spark & Flink Tests
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:intTest
+          ./gradlew --continue --scan :authmgr-oauth2-runtime-spark-tests:intTest :authmgr-oauth2-runtime-flink-tests:intTest
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: spark-tests-results
-          path: |
-            **/build/test-results/**
-
-  flink-tests:
-
-    runs-on: ubuntu-latest
-    name: Flink Runtime Tests
-    permissions:
-      contents: read
-
-    steps:
-
-      - name: Checkout Project
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
-          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
-          validate-wrappers: false
-
-      - name: Gradle Build Project Flink Tests
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: |
-          ./gradlew --continue --scan :authmgr-oauth2-runtime-flink-tests:intTest
-
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: flink-tests-results
+          name: runtime-tests-results
           path: |
             **/build/test-results/**

--- a/oauth2/core/build.gradle.kts
+++ b/oauth2/core/build.gradle.kts
@@ -90,8 +90,14 @@ dependencies {
 tasks.named<Test>("test").configure { maxParallelForks = 4 }
 
 tasks.named<Test>("intTest").configure {
-  maxParallelForks = 2
+  if (System.getenv("CI") == null) {
+    maxParallelForks = 2
+  }
   systemProperty("authmgr.it.long.total", System.getProperty("authmgr.it.long.total", "PT30S"))
+  useJUnitPlatform {
+    project.findProperty("includeTags")?.let { includeTags = (it as String).split(',').toSet() }
+    project.findProperty("excludeTags")?.let { excludeTags = (it as String).split(',').toSet() }
+  }
 }
 
 val mockitoAgent = configurations.create("mockitoAgent")

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakLongIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakLongIT.java
@@ -25,10 +25,12 @@ import com.dremio.iceberg.authmgr.oauth2.test.ImmutableTestEnvironment.Builder;
 import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.container.KeycloakTestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(KeycloakTestEnvironment.class)
+@Tag("long")
 public class OAuth2AgentKeycloakLongIT extends OAuth2AgentLongITBase {
 
   @Test

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentPolarisLongIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentPolarisLongIT.java
@@ -22,10 +22,12 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.dremio.iceberg.authmgr.oauth2.test.ImmutableTestEnvironment.Builder;
 import com.dremio.iceberg.authmgr.oauth2.test.container.PolarisTestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(PolarisTestEnvironment.class)
+@Tag("long")
 public class OAuth2AgentPolarisLongIT extends OAuth2AgentLongITBase {
 
   @Test

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/container/PolarisContainer.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/container/PolarisContainer.java
@@ -42,7 +42,8 @@ public class PolarisContainer extends GenericContainer<PolarisContainer> {
 
   @SuppressWarnings("resource")
   public PolarisContainer() {
-    super("apache/polaris:latest");
+    // TODO use apache/polaris:1.0.0 once it's available
+    super("alexdut/polaris:1.0.0-incubating-rc2");
     withLogConsumer(new Slf4jLogConsumer(LOGGER));
     withExposedPorts(8181, 8182);
     waitingFor(

--- a/oauth2/runtime-flink-tests/build.gradle.kts
+++ b/oauth2/runtime-flink-tests/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
 }
 
 tasks.named<Test>("intTest").configure {
+  if (System.getenv("CI") == null) {
+    maxParallelForks = 2
+  }
   dependsOn(":authmgr-oauth2-runtime:shadowJar")
   environment("AWS_REGION", "us-west-2")
   environment("AWS_ACCESS_KEY_ID", "fake")

--- a/oauth2/runtime-spark-tests/build.gradle.kts
+++ b/oauth2/runtime-spark-tests/build.gradle.kts
@@ -56,6 +56,9 @@ dependencies {
 }
 
 tasks.named<Test>("intTest").configure {
+  if (System.getenv("CI") == null) {
+    maxParallelForks = 2
+  }
   dependsOn(":authmgr-oauth2-runtime:shadowJar")
   environment("AWS_REGION", "us-west-2")
   environment("AWS_ACCESS_KEY_ID", "fake")


### PR DESCRIPTION
The CI builds started hanging a few days ago. I fear this could be related to the ARM runners, so let's revert the changes around Docker in CI to eliminate this possible culprit.