### PR TITLE
fix(ci): Lower parallelism of unit tests

### DIFF
--- a/oauth2/core/build.gradle.kts
+++ b/oauth2/core/build.gradle.kts
@@ -87,7 +87,11 @@ dependencies {
   intTestAnnotationProcessor(project(":authmgr-immutables", configuration = "processor"))
 }
 
-tasks.named<Test>("test").configure { maxParallelForks = 4 }
+tasks.named<Test>("test").configure {
+  if (System.getenv("CI") == null) {
+    maxParallelForks = 4
+  }
+}
 
 tasks.named<Test>("intTest").configure {
   if (System.getenv("CI") == null) {


### PR DESCRIPTION
Unit tests seem to hang as well, trying to see if setting parallelism back to 1 makes things better.