### PR TITLE
fix(test): Use CompletableFuture.get() to avoid masking InterruptedExceptions

### DIFF
--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
@@ -76,7 +76,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void clientSecretBasic(GrantType initialGrantType, Builder envBuilder) {
+  void clientSecretBasic(GrantType initialGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(initialGrantType)
@@ -100,7 +101,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void clientSecretPost(GrantType initialGrantType, Builder envBuilder) {
+  void clientSecretPost(GrantType initialGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(initialGrantType)
@@ -116,7 +118,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void publicClient(GrantType initialGrantType, Builder envBuilder) {
+  void publicClient(GrantType initialGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(initialGrantType)
@@ -135,7 +138,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void clientSecretJwt(GrantType initialGrantType, Builder envBuilder) {
+  void clientSecretJwt(GrantType initialGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(initialGrantType)
@@ -153,7 +157,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void privateKeyJwt(GrantType initialGrantType, Builder envBuilder) {
+  void privateKeyJwt(GrantType initialGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(initialGrantType)
@@ -173,7 +178,8 @@ public class OAuth2AgentKeycloakIT {
 
   @ParameterizedTest
   @CsvSource({"false, S256", "true, S256", "true, PLAIN"})
-  void pkce(boolean enabled, PkceTransformation transformation, Builder envBuilder) {
+  void pkce(boolean enabled, PkceTransformation transformation, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(AUTHORIZATION_CODE)
@@ -194,7 +200,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void impersonation1(GrantType subjectGrantType, Builder envBuilder) {
+  void impersonation1(GrantType subjectGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(TOKEN_EXCHANGE)
@@ -216,7 +223,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void impersonation2(GrantType subjectGrantType, Builder envBuilder) {
+  void impersonation2(GrantType subjectGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             envBuilder
                 .grantType(TOKEN_EXCHANGE)
@@ -278,7 +286,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void delegation3(GrantType subjectGrantType, Builder envBuilder) {
+  void delegation3(GrantType subjectGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     boolean expectRefreshToken = subjectGrantType != GrantType.CLIENT_CREDENTIALS;
     try (TestEnvironment env =
             envBuilder
@@ -307,7 +316,8 @@ public class OAuth2AgentKeycloakIT {
   @EnumSource(
       value = GrantType.class,
       names = {"CLIENT_CREDENTIALS", "PASSWORD", "AUTHORIZATION_CODE", "DEVICE_CODE"})
-  void delegation4(GrantType subjectGrantType, Builder envBuilder) {
+  void delegation4(GrantType subjectGrantType, Builder envBuilder)
+      throws ExecutionException, InterruptedException {
     boolean expectRefreshToken = subjectGrantType != GrantType.CLIENT_CREDENTIALS;
     try (TestEnvironment env =
             envBuilder
@@ -461,21 +471,22 @@ public class OAuth2AgentKeycloakIT {
     }
   }
 
-  private void assertAgent(OAuth2Agent agent, String clientId, boolean expectRefreshToken) {
+  private void assertAgent(OAuth2Agent agent, String clientId, boolean expectRefreshToken)
+      throws ExecutionException, InterruptedException {
     // initial grant
     Tokens initial = agent.authenticateInternal();
     introspectToken(initial.getAccessToken(), clientId);
     // token refresh
     if (expectRefreshToken) {
       soft.assertThat(initial.getRefreshToken()).isNotNull();
-      Tokens refreshed = agent.refreshCurrentTokens(initial).toCompletableFuture().join();
+      Tokens refreshed = agent.refreshCurrentTokens(initial).toCompletableFuture().get();
       introspectToken(refreshed.getAccessToken(), clientId);
       soft.assertThat(refreshed.getRefreshToken()).isNotNull();
     } else {
       soft.assertThat(initial.getRefreshToken()).isNull();
     }
     // fetch new tokens
-    Tokens renewed = agent.fetchNewTokens().toCompletableFuture().join();
+    Tokens renewed = agent.fetchNewTokens().toCompletableFuture().get();
     introspectToken(renewed.getAccessToken(), clientId);
     if (expectRefreshToken) {
       soft.assertThat(renewed.getRefreshToken()).isNotNull();

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakLongIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakLongIT.java
@@ -25,6 +25,7 @@ import com.dremio.iceberg.authmgr.oauth2.test.ImmutableTestEnvironment.Builder;
 import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.container.KeycloakTestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +35,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class OAuth2AgentKeycloakLongIT extends OAuth2AgentLongITBase {
 
   @Test
-  void backgroundRefreshAndSleep(Builder envBuilder1, Builder envBuilder2) {
+  void backgroundRefreshAndSleep(Builder envBuilder1, Builder envBuilder2)
+      throws ExecutionException, InterruptedException {
     run(envBuilder1, envBuilder2.grantType(TOKEN_EXCHANGE).subjectGrantType(AUTHORIZATION_CODE));
   }
 

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentPolarisIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentPolarisIT.java
@@ -39,7 +39,7 @@ public class OAuth2AgentPolarisIT {
   @InjectSoftAssertions private SoftAssertions soft;
 
   @Test
-  void clientCredentials(Builder envBuilder) {
+  void clientCredentials(Builder envBuilder) throws ExecutionException, InterruptedException {
     try (TestEnvironment env = envBuilder.build();
         OAuth2Agent agent = env.newAgent()) {
       // initial grant
@@ -47,7 +47,7 @@ public class OAuth2AgentPolarisIT {
       introspectToken(firstTokens.getAccessToken());
       soft.assertThat(firstTokens.getRefreshToken()).isNull();
       // token refresh
-      Tokens refreshedTokens = agent.refreshCurrentTokens(firstTokens).toCompletableFuture().join();
+      Tokens refreshedTokens = agent.refreshCurrentTokens(firstTokens).toCompletableFuture().get();
       introspectToken(refreshedTokens.getAccessToken());
       soft.assertThat(refreshedTokens.getRefreshToken()).isNull();
     }
@@ -59,7 +59,7 @@ public class OAuth2AgentPolarisIT {
    * and secret to authenticate with.
    */
   @Test
-  void fixedToken(Builder envBuilder) {
+  void fixedToken(Builder envBuilder) throws ExecutionException, InterruptedException {
     AccessToken accessToken;
     try (TestEnvironment env = envBuilder.build();
         OAuth2Agent agent = env.newAgent()) {
@@ -73,7 +73,7 @@ public class OAuth2AgentPolarisIT {
           .isEqualTo(accessToken.getPayload());
       soft.assertThat(firstTokens.getRefreshToken()).isNull();
       // token refresh
-      Tokens refreshedTokens = agent.refreshCurrentTokens(firstTokens).toCompletableFuture().join();
+      Tokens refreshedTokens = agent.refreshCurrentTokens(firstTokens).toCompletableFuture().get();
       introspectToken(refreshedTokens.getAccessToken());
       soft.assertThat(refreshedTokens.getRefreshToken()).isNull();
       // cannot fetch new tokens

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentPolarisLongIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentPolarisLongIT.java
@@ -22,6 +22,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.dremio.iceberg.authmgr.oauth2.test.ImmutableTestEnvironment.Builder;
 import com.dremio.iceberg.authmgr.oauth2.test.container.PolarisTestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +32,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class OAuth2AgentPolarisLongIT extends OAuth2AgentLongITBase {
 
   @Test
-  void backgroundRefreshAndSleep(Builder envBuilder1, Builder envBuilder2) {
+  void backgroundRefreshAndSleep(Builder envBuilder1, Builder envBuilder2)
+      throws ExecutionException, InterruptedException {
     run(envBuilder1, envBuilder2);
   }
 

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlowTest.java
@@ -21,6 +21,7 @@ import com.dremio.iceberg.authmgr.oauth2.config.PkceTransformation;
 import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -45,7 +46,8 @@ class AuthorizationCodeFlowTest {
       boolean pkceEnabled,
       PkceTransformation pkceTransformation,
       boolean privateClient,
-      boolean returnRefreshTokens) {
+      boolean returnRefreshTokens)
+      throws InterruptedException, ExecutionException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.AUTHORIZATION_CODE)
@@ -56,7 +58,7 @@ class AuthorizationCodeFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlowTest.java
@@ -19,16 +19,17 @@ import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertToken
 
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
 class ClientCredentialsFlowTest {
 
   @Test
-  void fetchNewTokens() {
+  void fetchNewTokens() throws InterruptedException, ExecutionException {
     try (TestEnvironment env = TestEnvironment.builder().build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlowTest.java
@@ -22,6 +22,7 @@ import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -29,7 +30,8 @@ class DeviceCodeFlowTest {
 
   @ParameterizedTest
   @CsvSource({"true, true", "true, false", "false, true", "false, false"})
-  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens) {
+  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.DEVICE_CODE)
@@ -44,7 +46,7 @@ class DeviceCodeFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergClientCredentialsFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergClientCredentialsFlowTest.java
@@ -20,16 +20,17 @@ import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertToken
 import com.dremio.iceberg.authmgr.oauth2.config.Dialect;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
 class IcebergClientCredentialsFlowTest {
 
   @Test
-  void fetchNewTokens() {
+  void fetchNewTokens() throws InterruptedException, ExecutionException {
     try (TestEnvironment env = TestEnvironment.builder().dialect(Dialect.ICEBERG_REST).build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlowTest.java
@@ -22,6 +22,7 @@ import com.dremio.iceberg.authmgr.oauth2.config.Dialect;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
 class IcebergRefreshTokenFlowTest {
@@ -30,17 +31,17 @@ class IcebergRefreshTokenFlowTest {
       Tokens.of(AccessToken.of("access_initial", "Bearer", ACCESS_TOKEN_EXPIRATION_TIME), null);
 
   @Test
-  void fetchNewTokens() {
+  void fetchNewTokens() throws InterruptedException, ExecutionException {
     try (TestEnvironment env = TestEnvironment.builder().dialect(Dialect.ICEBERG_REST).build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createTokenRefreshFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
       assertTokens(tokens, "access_refreshed", null);
     }
   }
 
   @Test
-  void fetchNewTokensBearerAuth() {
+  void fetchNewTokensBearerAuth() throws InterruptedException, ExecutionException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .dialect(Dialect.ICEBERG_REST)
@@ -48,7 +49,7 @@ class IcebergRefreshTokenFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createTokenRefreshFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
       assertTokens(tokens, "access_refreshed", null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlowTest.java
@@ -20,6 +20,7 @@ import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertToken
 import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -27,7 +28,8 @@ class PasswordFlowTest {
 
   @ParameterizedTest
   @CsvSource({"true, true", "true, false", "false, true", "false, false"})
-  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens) {
+  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens)
+      throws InterruptedException, ExecutionException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.PASSWORD)
@@ -36,7 +38,7 @@ class PasswordFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlowTest.java
@@ -24,6 +24,7 @@ import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
 import com.dremio.iceberg.authmgr.oauth2.token.RefreshToken;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -36,7 +37,8 @@ class RefreshTokenFlowTest {
 
   @ParameterizedTest
   @CsvSource({"true, true", "true, false", "false, true", "false, false"})
-  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens) {
+  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens)
+      throws ExecutionException, InterruptedException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.AUTHORIZATION_CODE)
@@ -45,7 +47,7 @@ class RefreshTokenFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createTokenRefreshFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
       assertTokens(
           tokens,
           "access_refreshed",

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
@@ -24,6 +24,7 @@ import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
 import com.dremio.iceberg.authmgr.oauth2.token.RefreshToken;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -36,7 +37,8 @@ class TokenExchangeFlowTest {
 
   @ParameterizedTest
   @CsvSource({"true, true", "true, false", "false, true", "false, false"})
-  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens) {
+  void fetchNewTokens(boolean privateClient, boolean returnRefreshTokens)
+      throws InterruptedException, ExecutionException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.TOKEN_EXCHANGE)
@@ -45,7 +47,7 @@ class TokenExchangeFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }
@@ -67,7 +69,8 @@ class TokenExchangeFlowTest {
     "false, false, DEVICE_CODE",
   })
   void fetchNewTokensDynamic(
-      boolean privateClient, boolean returnRefreshTokens, GrantType grantType) {
+      boolean privateClient, boolean returnRefreshTokens, GrantType grantType)
+      throws InterruptedException, ExecutionException {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .grantType(GrantType.TOKEN_EXCHANGE)
@@ -80,7 +83,7 @@ class TokenExchangeFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().join();
+      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/runtime-flink-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/flink/FlinkPolarisS3ITBase.java
+++ b/oauth2/runtime-flink-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/flink/FlinkPolarisS3ITBase.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterators;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.junit.jupiter.api.AfterAll;
@@ -45,9 +46,9 @@ public abstract class FlinkPolarisS3ITBase {
   protected TableEnvironment flink;
 
   @BeforeAll
-  public void setup() {
+  public void setup() throws ExecutionException, InterruptedException {
     var network = Network.newNetwork();
-    startAllContainers(network).join();
+    startAllContainers(network).get();
     EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
     flink = TableEnvironment.create(settings);
     createFlinkCatalog(flinkCatalogOptions());

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkS3ITBase.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,9 +43,9 @@ public abstract class SparkS3ITBase {
   protected SparkSession spark;
 
   @BeforeAll
-  public void setup(@TempDir Path tempDir) {
+  public void setup(@TempDir Path tempDir) throws ExecutionException, InterruptedException {
     var network = Network.newNetwork();
-    startAllContainers(network).join();
+    startAllContainers(network).get();
     Map<String, Object> sparkConfig = sparkConfig(tempDir);
     spark = SparkSession.builder().master("local[1]").config(sparkConfig).getOrCreate();
   }


### PR DESCRIPTION
This change modifies all the tests that were calling `CompletableFuture.join()` out of convenience, since this method does not throw checked exceptions.

Unfortunately, `.join()` also masks any `InterruptedException` behind a `CompletionException`. This seems to interfere with JUnit's ability to properly interrupt a test after a timeout, at least on Linux.