### PR TITLE
chore(oauth): Refactor Flow API to distinguish initial vs refresh flows

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
@@ -102,14 +102,13 @@ abstract class AbstractFlow implements Flow {
         .thenApply(resp -> resp.asTokens(getSpec().getRuntimeConfig().getClock()));
   }
 
-  protected CompletionStage<DeviceAuthorizationResponse> invokeDeviceAuthEndpoint(
-      @Nullable Tokens currentTokens) {
+  protected CompletionStage<DeviceAuthorizationResponse> invokeDeviceAuthEndpoint() {
     URI deviceAuthorizationEndpoint =
         Objects.requireNonNull(getEndpointProvider().getResolvedDeviceAuthorizationEndpoint());
     DeviceAuthorizationRequest.Builder builder = DeviceAuthorizationRequest.builder();
     ConfigUtils.scopesAsString(getSpec().getBasicConfig().getScopes()).ifPresent(builder::scope);
     Map<String, String> headers = getHeaders();
-    getClientAuthenticator().authenticate(builder, headers, currentTokens);
+    getClientAuthenticator().authenticate(builder, headers, null);
     DeviceAuthorizationRequest request = builder.build();
     return CompletableFuture.supplyAsync(
             () -> {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * flow.
  */
 @AuthManagerImmutable
-abstract class AuthorizationCodeFlow extends AbstractFlow {
+abstract class AuthorizationCodeFlow extends AbstractFlow implements InitialFlow {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationCodeFlow.class);
 
@@ -195,7 +195,7 @@ abstract class AuthorizationCodeFlow extends AbstractFlow {
   }
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(@Nullable Tokens ignored) {
+  public CompletionStage<Tokens> fetchNewTokens() {
     LOGGER.debug(
         "[{}] Authorization Code Flow: started, redirect URI: {}",
         getAgentName(),

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlow.java
@@ -18,7 +18,6 @@ package com.dremio.iceberg.authmgr.oauth2.flow;
 import com.dremio.iceberg.authmgr.oauth2.rest.ClientCredentialsTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
-import jakarta.annotation.Nullable;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -27,13 +26,13 @@ import java.util.concurrent.CompletionStage;
  * flow.
  */
 @AuthManagerImmutable
-abstract class ClientCredentialsFlow extends AbstractFlow {
+abstract class ClientCredentialsFlow extends AbstractFlow implements InitialFlow {
 
   interface Builder extends AbstractFlow.Builder<ClientCredentialsFlow, Builder> {}
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(@Nullable Tokens currentTokens) {
+  public CompletionStage<Tokens> fetchNewTokens() {
     ClientCredentialsTokenRequest.Builder request = ClientCredentialsTokenRequest.builder();
-    return invokeTokenEndpoint(currentTokens, request);
+    return invokeTokenEndpoint(null, request);
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
@@ -21,7 +21,6 @@ import static com.dremio.iceberg.authmgr.oauth2.flow.FlowUtils.OAUTH2_AGENT_TITL
 import com.dremio.iceberg.authmgr.oauth2.rest.DeviceAccessTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
-import jakarta.annotation.Nullable;
 import java.io.PrintStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * Authorization Grant</a> flow.
  */
 @AuthManagerImmutable
-abstract class DeviceCodeFlow extends AbstractFlow {
+abstract class DeviceCodeFlow extends AbstractFlow implements InitialFlow {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DeviceCodeFlow.class);
 
@@ -82,9 +81,9 @@ abstract class DeviceCodeFlow extends AbstractFlow {
   }
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(@Nullable Tokens currentTokens) {
+  public CompletionStage<Tokens> fetchNewTokens() {
     LOGGER.debug("[{}] Device Auth Flow: started", getAgentName());
-    return invokeDeviceAuthEndpoint(currentTokens)
+    return invokeDeviceAuthEndpoint()
         .thenCompose(
             response -> {
               pollInterval = getSpec().getDeviceCodeConfig().getPollInterval();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/Flow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/Flow.java
@@ -15,8 +15,6 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
-import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
-import jakarta.annotation.Nullable;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -28,15 +26,8 @@ import java.util.concurrent.CompletionStage;
  *
  * <p>A flow may be stateful or stateless. Stateful flows should clean up internal resources when
  * the returned {@link CompletionStage} completes.
+ *
+ * @see InitialFlow
+ * @see RefreshFlow
  */
-public interface Flow {
-
-  /**
-   * Fetches new tokens from the OAuth2 provider. This method is called when the current tokens are
-   * expired or about to expire, and new tokens are needed.
-   *
-   * @param currentTokens The current tokens. This can be null if no tokens are available.
-   * @return The new tokens fetched from the OAuth2 provider.
-   */
-  CompletionStage<Tokens> fetchNewTokens(@Nullable Tokens currentTokens);
-}
+public interface Flow {}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/Flow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/Flow.java
@@ -15,17 +15,12 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
-import java.util.concurrent.CompletionStage;
-
 /**
- * An interface representing an OAuth2 flow. A flow is used to fetch new tokens from the OAuth2
- * provider.
+ * An interface representing an OAuth2 flow.
  *
  * <p>A flow is a short-lived component that represents a set of interactions (generally one, but
- * sometimes more) between the agent and the server, in order to obtain access tokens.
- *
- * <p>A flow may be stateful or stateless. Stateful flows should clean up internal resources when
- * the returned {@link CompletionStage} completes.
+ * sometimes more) between the agent and the OAuth2 authorization server, in order to obtain access
+ * tokens.
  *
  * @see InitialFlow
  * @see RefreshFlow

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowFactory.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowFactory.java
@@ -46,7 +46,7 @@ public abstract class FlowFactory implements AutoCloseable {
   }
 
   /** Creates a flow for fetching new tokens. This is used for the initial token fetch. */
-  public Flow createInitialFlow() {
+  public InitialFlow createInitialFlow() {
     return newInitialFlowBuilder()
         .spec(getSpec())
         .executor(getExecutor())
@@ -60,7 +60,7 @@ public abstract class FlowFactory implements AutoCloseable {
    * Creates a flow for refreshing tokens. This is used for refreshing tokens when the access token
    * expires.
    */
-  public Flow createTokenRefreshFlow() {
+  public RefreshFlow createTokenRefreshFlow() {
     return newTokenRefreshFlowBuilder()
         .spec(getSpec())
         .executor(getExecutor())
@@ -125,7 +125,7 @@ public abstract class FlowFactory implements AutoCloseable {
         : ActorTokenSupplier.of(getSpec(), getExecutor(), getRestClientSupplier());
   }
 
-  private AbstractFlow.Builder<?, ?> newInitialFlowBuilder() {
+  private AbstractFlow.Builder<? extends InitialFlow, ?> newInitialFlowBuilder() {
     switch (getSpec().getBasicConfig().getGrantType()) {
       case CLIENT_CREDENTIALS:
         return ImmutableClientCredentialsFlow.builder();
@@ -146,7 +146,7 @@ public abstract class FlowFactory implements AutoCloseable {
     }
   }
 
-  private AbstractFlow.Builder<?, ?> newTokenRefreshFlowBuilder() {
+  private AbstractFlow.Builder<? extends RefreshFlow, ?> newTokenRefreshFlowBuilder() {
     switch (getSpec().getBasicConfig().getDialect()) {
       case STANDARD:
         return ImmutableRefreshTokenFlow.builder();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlow.java
@@ -27,12 +27,12 @@ import java.util.concurrent.CompletionStage;
  * dialect only.
  */
 @AuthManagerImmutable
-abstract class IcebergRefreshTokenFlow extends AbstractFlow {
+abstract class IcebergRefreshTokenFlow extends AbstractFlow implements RefreshFlow {
 
   interface Builder extends AbstractFlow.Builder<IcebergRefreshTokenFlow, Builder> {}
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(Tokens currentTokens) {
+  public CompletionStage<Tokens> refreshTokens(Tokens currentTokens) {
     Objects.requireNonNull(currentTokens, "currentTokens is null");
     Objects.requireNonNull(
         currentTokens.getAccessToken(), "currentTokens.getAccessToken() is null");

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/InitialFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/InitialFlow.java
@@ -15,22 +15,19 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
-import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokens;
-
-import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
-import java.util.concurrent.ExecutionException;
-import org.junit.jupiter.api.Test;
+import java.util.concurrent.CompletionStage;
 
-class ClientCredentialsFlowTest {
+/** An interface representing an "initial" OAuth2 flow that can be used to fetch new tokens. */
+public interface InitialFlow extends Flow {
 
-  @Test
-  void fetchNewTokens() throws InterruptedException, ExecutionException {
-    try (TestEnvironment env = TestEnvironment.builder().build();
-        FlowFactory flowFactory = env.newFlowFactory()) {
-      InitialFlow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokens(tokens, "access_initial", null);
-    }
-  }
+  /**
+   * Fetches brand-new tokens from the OAuth2 provider.
+   *
+   * <p>This method is called when new tokens are needed, either because no current tokens exist, or
+   * because the current tokens are expired or about to expire.
+   *
+   * @return A stage that completes when brand-new tokens are fetched.
+   */
+  CompletionStage<Tokens> fetchNewTokens();
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/InitialFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/InitialFlow.java
@@ -27,6 +27,9 @@ public interface InitialFlow extends Flow {
    * <p>This method is called when new tokens are needed, either because no current tokens exist, or
    * because the current tokens are expired or about to expire.
    *
+   * <p>A flow may be stateful or stateless. Stateful flows should clean up internal resources when
+   * the returned {@link CompletionStage} completes.
+   *
    * @return A stage that completes when brand-new tokens are fetched.
    */
   CompletionStage<Tokens> fetchNewTokens();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlow.java
@@ -19,7 +19,6 @@ import com.dremio.iceberg.authmgr.oauth2.config.Secret;
 import com.dremio.iceberg.authmgr.oauth2.rest.PasswordTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
-import jakarta.annotation.Nullable;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -28,12 +27,12 @@ import java.util.concurrent.CompletionStage;
  * Credentials Grant</a> flow.
  */
 @AuthManagerImmutable
-abstract class PasswordFlow extends AbstractFlow {
+abstract class PasswordFlow extends AbstractFlow implements InitialFlow {
 
   interface Builder extends AbstractFlow.Builder<PasswordFlow, Builder> {}
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(@Nullable Tokens currentTokens) {
+  public CompletionStage<Tokens> fetchNewTokens() {
     String username =
         getSpec()
             .getResourceOwnerConfig()
@@ -47,6 +46,6 @@ abstract class PasswordFlow extends AbstractFlow {
             .orElseThrow(() -> new IllegalStateException("Password is required"));
     PasswordTokenRequest.Builder request =
         PasswordTokenRequest.builder().username(username).password(password);
-    return invokeTokenEndpoint(currentTokens, request);
+    return invokeTokenEndpoint(null, request);
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshFlow.java
@@ -15,22 +15,17 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
-import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokens;
-
-import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
-import java.util.concurrent.ExecutionException;
-import org.junit.jupiter.api.Test;
+import java.util.concurrent.CompletionStage;
 
-class ClientCredentialsFlowTest {
+/** An interface representing an OAuth2 flow that can be used to refresh existing tokens. */
+public interface RefreshFlow extends Flow {
 
-  @Test
-  void fetchNewTokens() throws InterruptedException, ExecutionException {
-    try (TestEnvironment env = TestEnvironment.builder().build();
-        FlowFactory flowFactory = env.newFlowFactory()) {
-      InitialFlow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokens(tokens, "access_initial", null);
-    }
-  }
+  /**
+   * Refreshes the current tokens.
+   *
+   * @param currentTokens The current tokens. Cannot be null.
+   * @return A future that completes when the tokens are refreshed.
+   */
+  CompletionStage<Tokens> refreshTokens(Tokens currentTokens);
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshFlow.java
@@ -24,6 +24,9 @@ public interface RefreshFlow extends Flow {
   /**
    * Refreshes the current tokens.
    *
+   * <p>A flow may be stateful or stateless. Stateful flows should clean up internal resources when
+   * the returned {@link CompletionStage} completes.
+   *
    * @param currentTokens The current tokens. Cannot be null.
    * @return A future that completes when the tokens are refreshed.
    */

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlow.java
@@ -18,7 +18,6 @@ package com.dremio.iceberg.authmgr.oauth2.flow;
 import com.dremio.iceberg.authmgr.oauth2.rest.RefreshTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
-import jakarta.annotation.Nullable;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
@@ -27,12 +26,12 @@ import java.util.concurrent.CompletionStage;
  * Refresh</a> flow.
  */
 @AuthManagerImmutable
-abstract class RefreshTokenFlow extends AbstractFlow {
+abstract class RefreshTokenFlow extends AbstractFlow implements RefreshFlow {
 
   interface Builder extends AbstractFlow.Builder<RefreshTokenFlow, Builder> {}
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(@Nullable Tokens currentTokens) {
+  public CompletionStage<Tokens> refreshTokens(Tokens currentTokens) {
     Objects.requireNonNull(currentTokens, "currentTokens is null");
     Objects.requireNonNull(
         currentTokens.getRefreshToken(), "currentTokens.getRefreshTokens() is null");

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletionStage;
  * Exchange</a> flow.
  */
 @AuthManagerImmutable
-abstract class TokenExchangeFlow extends AbstractFlow {
+abstract class TokenExchangeFlow extends AbstractFlow implements InitialFlow {
 
   interface Builder extends AbstractFlow.Builder<TokenExchangeFlow, Builder> {
     @CanIgnoreReturnValue
@@ -43,7 +43,7 @@ abstract class TokenExchangeFlow extends AbstractFlow {
   abstract CompletionStage<TypedToken> actorTokenStage();
 
   @Override
-  public CompletionStage<Tokens> fetchNewTokens(Tokens currentTokens) {
+  public CompletionStage<Tokens> fetchNewTokens() {
     return subjectTokenStage()
         .thenCombine(
             actorTokenStage(),
@@ -59,6 +59,6 @@ abstract class TokenExchangeFlow extends AbstractFlow {
                   .audience(getSpec().getTokenExchangeConfig().getAudience().orElse(null))
                   .requestedTokenType(getSpec().getTokenExchangeConfig().getRequestedTokenType());
             })
-        .thenCompose(request -> invokeTokenEndpoint(currentTokens, request));
+        .thenCompose(request -> invokeTokenEndpoint(null, request));
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlowTest.java
@@ -57,8 +57,8 @@ class AuthorizationCodeFlowTest {
                 .returnRefreshTokens(returnRefreshTokens)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
+      InitialFlow flow = flowFactory.createInitialFlow();
+      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlowTest.java
@@ -45,8 +45,8 @@ class DeviceCodeFlowTest {
                 .returnRefreshTokens(returnRefreshTokens)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
+      InitialFlow flow = flowFactory.createInitialFlow();
+      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergClientCredentialsFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergClientCredentialsFlowTest.java
@@ -29,8 +29,8 @@ class IcebergClientCredentialsFlowTest {
   void fetchNewTokens() throws InterruptedException, ExecutionException {
     try (TestEnvironment env = TestEnvironment.builder().dialect(Dialect.ICEBERG_REST).build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
+      InitialFlow flow = flowFactory.createInitialFlow();
+      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokens(tokens, "access_initial", null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlowTest.java
@@ -34,8 +34,8 @@ class IcebergRefreshTokenFlowTest {
   void fetchNewTokens() throws InterruptedException, ExecutionException {
     try (TestEnvironment env = TestEnvironment.builder().dialect(Dialect.ICEBERG_REST).build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createTokenRefreshFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
+      RefreshFlow flow = flowFactory.createTokenRefreshFlow();
+      Tokens tokens = flow.refreshTokens(currentTokens).toCompletableFuture().get();
       assertTokens(tokens, "access_refreshed", null);
     }
   }
@@ -48,8 +48,8 @@ class IcebergRefreshTokenFlowTest {
                 .token("access_initial")
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createTokenRefreshFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
+      RefreshFlow flow = flowFactory.createTokenRefreshFlow();
+      Tokens tokens = flow.refreshTokens(currentTokens).toCompletableFuture().get();
       assertTokens(tokens, "access_refreshed", null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlowTest.java
@@ -37,8 +37,8 @@ class PasswordFlowTest {
                 .returnRefreshTokens(returnRefreshTokens)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(null).toCompletableFuture().get();
+      InitialFlow flow = flowFactory.createInitialFlow();
+      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlowTest.java
@@ -46,8 +46,8 @@ class RefreshTokenFlowTest {
                 .returnRefreshTokens(returnRefreshTokens)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createTokenRefreshFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
+      RefreshFlow flow = flowFactory.createTokenRefreshFlow();
+      Tokens tokens = flow.refreshTokens(currentTokens).toCompletableFuture().get();
       assertTokens(
           tokens,
           "access_refreshed",

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
@@ -15,25 +15,16 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_EXPIRATION_TIME;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_EXPIRATION_TIME;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokens;
 
 import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
-import com.dremio.iceberg.authmgr.oauth2.token.AccessToken;
-import com.dremio.iceberg.authmgr.oauth2.token.RefreshToken;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class TokenExchangeFlowTest {
-
-  private final Tokens currentTokens =
-      Tokens.of(
-          AccessToken.of("access_initial", "Bearer", ACCESS_TOKEN_EXPIRATION_TIME),
-          RefreshToken.of("refresh_initial", REFRESH_TOKEN_EXPIRATION_TIME));
 
   @ParameterizedTest
   @CsvSource({"true, true", "true, false", "false, true", "false, false"})
@@ -46,8 +37,8 @@ class TokenExchangeFlowTest {
                 .returnRefreshTokens(returnRefreshTokens)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
+      InitialFlow flow = flowFactory.createInitialFlow();
+      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }
@@ -82,8 +73,8 @@ class TokenExchangeFlowTest {
                 .actorGrantType(grantType)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
-      Flow flow = flowFactory.createInitialFlow();
-      Tokens tokens = flow.fetchNewTokens(currentTokens).toCompletableFuture().get();
+      InitialFlow flow = flowFactory.createInitialFlow();
+      Tokens tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokens(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
     }
   }


### PR DESCRIPTION
This change is a pure refactor of the Flow API to make it more explicit about the usage of current tokens. There is no functional change.