### PR TITLE
fix(oauth): Prevent race conditions between close() and future cancellation

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/concurrent/AutoCloseables.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/concurrent/AutoCloseables.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.concurrent;
+
+import jakarta.annotation.Nullable;
+import java.util.concurrent.Future;
+
+public final class AutoCloseables {
+
+  public interface UncheckedAutoCloseable extends AutoCloseable {
+    @Override
+    void close();
+  }
+
+  public static final UncheckedAutoCloseable NO_OP = () -> {};
+
+  private AutoCloseables() {}
+
+  /** Returns an {@link UncheckedAutoCloseable} that runs the given runnable when closed. */
+  public static UncheckedAutoCloseable runOnClose(@Nullable Runnable runnable) {
+    return runnable == null ? NO_OP : runnable::run;
+  }
+
+  /** Returns an {@link UncheckedAutoCloseable} that cancels the given future when closed. */
+  public static UncheckedAutoCloseable cancelOnClose(@Nullable Future<?> future) {
+    return future == null ? NO_OP : runOnClose(() -> Futures.cancel(future));
+  }
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/concurrent/Futures.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/concurrent/Futures.java
@@ -17,7 +17,6 @@ package com.dremio.iceberg.authmgr.oauth2.concurrent;
 
 import jakarta.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,9 +34,8 @@ public final class Futures {
    * is completed exceptionally.
    */
   @Nullable
-  public static <T> T getNow(@Nullable CompletionStage<T> stage) {
-    if (stage != null) {
-      CompletableFuture<T> future = stage.toCompletableFuture();
+  public static <T> T getNow(@Nullable CompletableFuture<T> future) {
+    if (future != null) {
       if (future.isDone() && !future.isCompletedExceptionally() && !future.isCancelled()) {
         return future.join();
       }
@@ -48,23 +46,7 @@ public final class Futures {
   /** Cancels the given future if it is not null. */
   public static void cancel(@Nullable Future<?> future) {
     if (future != null) {
-      try {
-        future.cancel(true);
-      } catch (Exception e) {
-        LOGGER.warn("Error cancelling future", e);
-      }
-    }
-  }
-
-  /** Cancels the given future if it is not null. */
-  public static void cancel(@Nullable CompletableFuture<?> future) {
-    cancel((Future<?>) future);
-  }
-
-  /** Cancels the given future if it is not null. */
-  public static void cancel(@Nullable CompletionStage<?> future) {
-    if (future != null) {
-      cancel(future instanceof Future ? (Future<?>) future : future.toCompletableFuture());
+      future.cancel(true);
     }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/concurrent/AutoCloseablesTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/concurrent/AutoCloseablesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dremio.iceberg.authmgr.oauth2.concurrent.AutoCloseables.UncheckedAutoCloseable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class AutoCloseablesTest {
+
+  @Test
+  void runOnClose() {
+    UncheckedAutoCloseable closeable = AutoCloseables.runOnClose(null);
+    assertThatCode(closeable::close).doesNotThrowAnyException();
+  }
+
+  @Test
+  void runOnCloseWithRunnable() {
+    AtomicBoolean executed = new AtomicBoolean(false);
+    Runnable runnable = () -> executed.set(true);
+    UncheckedAutoCloseable closeable = AutoCloseables.runOnClose(runnable);
+    assertThat(executed).isFalse();
+    closeable.close();
+    assertThat(executed).isTrue();
+  }
+
+  @Test
+  void runOnCloseWithExceptionInRunnable() {
+    Runnable throwingRunnable =
+        () -> {
+          throw new RuntimeException("Test exception");
+        };
+    UncheckedAutoCloseable closeable = AutoCloseables.runOnClose(throwingRunnable);
+    assertThatCode(closeable::close)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Test exception");
+  }
+
+  @Test
+  void cancelOnCloseWithNullFuture() {
+    UncheckedAutoCloseable closeable = AutoCloseables.cancelOnClose(null);
+    assertThatCode(closeable::close).doesNotThrowAnyException();
+  }
+
+  @Test
+  void cancelOnCloseWithFuture() {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    UncheckedAutoCloseable closeable = AutoCloseables.cancelOnClose(future);
+    assertThat(future.isCancelled()).isFalse();
+    closeable.close();
+    assertThat(future.isCancelled()).isTrue();
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  void cancelOnCloseWithCompletedFuture() {
+    CompletableFuture<String> future = CompletableFuture.completedFuture("test");
+    UncheckedAutoCloseable closeable = AutoCloseables.cancelOnClose(future);
+    assertThatCode(closeable::close).doesNotThrowAnyException();
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCancelled()).isFalse();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void cancelOnCloseWithFailedFuture() {
+    Future<?> mockFuture = mock(Future.class);
+    when(mockFuture.cancel(true)).thenThrow(new RuntimeException("Cancel failed"));
+    UncheckedAutoCloseable closeable = AutoCloseables.cancelOnClose(mockFuture);
+    assertThatThrownBy(closeable::close)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Cancel failed");
+    verify(mockFuture).cancel(true);
+  }
+
+  @Test
+  void cancelOnCloseWithCancelledFuture() {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    future.cancel(true);
+    UncheckedAutoCloseable closeable = AutoCloseables.cancelOnClose(future);
+    assertThatCode(closeable::close).doesNotThrowAnyException();
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCancelled()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/concurrent/FuturesTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/concurrent/FuturesTest.java
@@ -17,13 +17,11 @@ package com.dremio.iceberg.authmgr.oauth2.concurrent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
 class FuturesTest {
@@ -44,9 +42,9 @@ class FuturesTest {
 
   @Test
   void cancelFuture() {
-    assertThatCode(() -> Futures.cancel((Future<?>) null)).doesNotThrowAnyException();
+    assertThatCode(() -> Futures.cancel(null)).doesNotThrowAnyException();
     CompletableFuture<?> future = new CompletableFuture<>();
-    Futures.cancel((Future<?>) future);
+    Futures.cancel(future);
     assertThat(future.isDone()).isTrue();
     assertThat(future.isCancelled()).isTrue();
     assertThat(future.isCompletedExceptionally()).isTrue();
@@ -56,43 +54,8 @@ class FuturesTest {
   void cancelFutureWithException() {
     CompletableFuture<?> future = mock(CompletableFuture.class);
     when(future.cancel(true)).thenThrow(new RuntimeException("test"));
-    assertThatCode(() -> Futures.cancel(future)).doesNotThrowAnyException();
-    verify(future).cancel(true);
-  }
-
-  @Test
-  void cancelCompletionStage() {
-    assertThatCode(() -> Futures.cancel((CompletionStage<?>) null)).doesNotThrowAnyException();
-    CompletableFuture<Object> future = new CompletableFuture<>();
-    Futures.cancel((CompletionStage<?>) future);
-    assertThat(future.isDone()).isTrue();
-    assertThat(future.isCancelled()).isTrue();
-    assertThat(future.isCompletedExceptionally()).isTrue();
-  }
-
-  @Test
-  void cancelCompletionStageWithException() {
-    CompletableFuture<?> future = mock(CompletableFuture.class);
-    when(future.cancel(true)).thenThrow(new RuntimeException("test"));
-    assertThatCode(() -> Futures.cancel((CompletionStage<?>) future)).doesNotThrowAnyException();
-    verify(future).cancel(true);
-  }
-
-  @Test
-  void cancelCompletableFuture() {
-    assertThatCode(() -> Futures.cancel((CompletableFuture<?>) null)).doesNotThrowAnyException();
-    CompletableFuture<Object> future = new CompletableFuture<>();
-    Futures.cancel(future);
-    assertThat(future.isDone()).isTrue();
-    assertThat(future.isCancelled()).isTrue();
-    assertThat(future.isCompletedExceptionally()).isTrue();
-  }
-
-  @Test
-  void cancelCompletableFutureWithException() {
-    CompletableFuture<?> future = mock(CompletableFuture.class);
-    when(future.cancel(true)).thenThrow(new RuntimeException("test"));
-    assertThatCode(() -> Futures.cancel(future)).doesNotThrowAnyException();
-    verify(future).cancel(true);
+    assertThatThrownBy(() -> Futures.cancel(future))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("test");
   }
 }


### PR DESCRIPTION
A few rare race conditions were spotted involving the thread executing close() and another thread executing token renewal logic.

Example 1:

* T1 enters `close()`
* T2 enters `renewTokens()`
* T1 sets `closing `to true
* T1 cancels `currentTokensStage`
* T2 assigns `currentTokensStage` to a new stage
* The new stage is not properly cancelled

Example 2:

* T1 enters `close()`
* T2 enters `scheduleTokensRenewal()`
* T1 sets `closing` to true
* T1 reads `tokenRefreshFuture`
* T2 assigns `tokenRefreshFuture` to a new future
* T1 cancels the old future
* T1 clears the `tokenRefreshFuture` field
* T2 calls `cancelTokenRefresh()`
* T2 reads `tokenRefreshFuture` and finds null
* The new future is not properly cancelled
* The field is not properly cleared

This change fixes both race conditions above.

This change also extracts utility methods for futures manipulation to a new `Futures` class.