### PR TITLE
feat(tests): Reduce memory and thread use of MockServer

### DIFF
--- a/oauth2/core/build.gradle.kts
+++ b/oauth2/core/build.gradle.kts
@@ -96,21 +96,18 @@ dependencies {
 }
 
 tasks.named<Test>("test").configure {
-  if (System.getenv("CI") == null) {
-    maxParallelForks = 4
-  }
+  configForks(4)
+  commonTestConfig()
 }
 
 tasks.named<Test>("intTest").configure {
-  if (System.getenv("CI") == null) {
-    maxParallelForks = 3
-  }
+  configForks(3)
+  commonTestConfig()
 }
 
 tasks.named<Test>("longTest").configure {
-  if (System.getenv("CI") == null) {
-    maxParallelForks = 3
-  }
+  configForks(3)
+  commonTestConfig()
   if (System.getProperty("authmgr.it.long.total") != null) {
     val total = Duration.parse(System.getProperty("authmgr.it.long.total"))
     systemProperty("authmgr.it.long.total", total.toIsoString())
@@ -131,3 +128,20 @@ dependencies {
 }
 
 tasks { test { jvmArgs("-javaagent:${mockitoAgent.asPath}") } }
+
+fun Test.configForks(forks: Int) {
+  if (System.getenv("CI") == null) {
+    maxParallelForks = forks
+  }
+}
+
+fun Test.commonTestConfig() {
+  val outputMemoryUsage = System.getProperty("authmgr.test.mockserver.outputMemoryUsage")
+  if (outputMemoryUsage.toBoolean()) {
+    val outputDir =
+      project.layout.buildDirectory.dir("reports/mockserver/${this.name}").get().asFile.absolutePath
+    outputs.dir(outputDir)
+    File(outputDir).mkdirs()
+    systemProperty("authmgr.test.mockserver.memoryUsageCsvDirectory", outputDir)
+  }
+}

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/server/UnitTestHttpServer.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/server/UnitTestHttpServer.java
@@ -15,12 +15,36 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.test.server;
 
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.mockserver.configuration.Configuration;
 import org.mockserver.integration.ClientAndServer;
 
 public class UnitTestHttpServer implements HttpServer {
 
-  private final ClientAndServer clientAndServer = ClientAndServer.startClientAndServer();
+  private static final AtomicInteger COUNTER = new AtomicInteger(1);
+
+  private final ClientAndServer clientAndServer;
+
+  public UnitTestHttpServer() {
+    Configuration configuration = Configuration.configuration();
+    String outputDir = System.getProperty("authmgr.test.mockserver.memoryUsageCsvDirectory");
+    if (outputDir != null) {
+      Path outputPath = Paths.get(outputDir).resolve("server-" + COUNTER.getAndIncrement());
+      try {
+        Files.createDirectories(outputPath);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      configuration.outputMemoryUsageCsv(true);
+      configuration.memoryUsageCsvDirectory(outputPath.toString());
+    }
+    clientAndServer = ClientAndServer.startClientAndServer(configuration);
+  }
 
   public ClientAndServer getClientAndServer() {
     return clientAndServer;

--- a/oauth2/core/src/testFixtures/resources/mockserver.properties
+++ b/oauth2/core/src/testFixtures/resources/mockserver.properties
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2025 Dremio Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See https://www.mock-server.com/mock_server/configuration_properties.html
+
+# Memory optimization - reduce limits based on observed usage patterns
+# Observed from CSV output: around 25 event log entries, max peak usage ~250MB heap
+mockserver.maxLogEntries=100
+mockserver.maxExpectations=50
+
+# Thread optimization - minimal threads for test environment
+mockserver.nioEventLoopThreadCount=1
+mockserver.actionHandlerThreadCount=1
+mockserver.clientNioEventLoopThreadCount=1
+mockserver.webSocketClientEventLoopThreadCount=2


### PR DESCRIPTION
MockServer can create a surprising amount of threads. 

This change aims at reducing the memory and CPU footprint of MockServer by reducing the number of threads to the minimum and by reducing some limits. 

This change also introduces the ability to print MockServer memory stats in CSV.