### PR TITLE
feat(oauth): Make OAuth2Agent agnostic of dialects

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
@@ -23,6 +23,7 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.PkceTransformation;
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.rest.AuthorizationCodeTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.oauth2.uri.UriBuilder;
@@ -66,6 +67,11 @@ abstract class AuthorizationCodeFlow extends AbstractFlow implements InitialFlow
   private static final int STATE_LENGTH = 16;
 
   interface Builder extends AbstractFlow.Builder<AuthorizationCodeFlow, Builder> {}
+
+  @Override
+  public GrantType getGrantType() {
+    return GrantType.AUTHORIZATION_CODE;
+  }
 
   @Value.Derived
   String getAgentName() {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlow.java
@@ -15,6 +15,7 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.rest.ClientCredentialsTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
@@ -29,6 +30,11 @@ import java.util.concurrent.CompletionStage;
 abstract class ClientCredentialsFlow extends AbstractFlow implements InitialFlow {
 
   interface Builder extends AbstractFlow.Builder<ClientCredentialsFlow, Builder> {}
+
+  @Override
+  public GrantType getGrantType() {
+    return GrantType.CLIENT_CREDENTIALS;
+  }
 
   @Override
   public CompletionStage<Tokens> fetchNewTokens() {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
@@ -18,6 +18,7 @@ package com.dremio.iceberg.authmgr.oauth2.flow;
 import static com.dremio.iceberg.authmgr.oauth2.flow.FlowUtils.OAUTH2_AGENT_OPEN_URL;
 import static com.dremio.iceberg.authmgr.oauth2.flow.FlowUtils.OAUTH2_AGENT_TITLE;
 
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.rest.DeviceAccessTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
@@ -42,6 +43,11 @@ abstract class DeviceCodeFlow extends AbstractFlow implements InitialFlow {
   private static final Logger LOGGER = LoggerFactory.getLogger(DeviceCodeFlow.class);
 
   interface Builder extends AbstractFlow.Builder<DeviceCodeFlow, Builder> {}
+
+  @Override
+  public GrantType getGrantType() {
+    return GrantType.DEVICE_CODE;
+  }
 
   @Value.Derived
   String getAgentName() {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/Flow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/Flow.java
@@ -15,6 +15,8 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
+
 /**
  * An interface representing an OAuth2 flow.
  *
@@ -25,4 +27,8 @@ package com.dremio.iceberg.authmgr.oauth2.flow;
  * @see InitialFlow
  * @see RefreshFlow
  */
-public interface Flow {}
+public interface Flow {
+
+  /** Returns the grant type used by this flow. */
+  GrantType getGrantType();
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/IcebergRefreshTokenFlow.java
@@ -15,6 +15,7 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.rest.TokenExchangeRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.oauth2.token.TypedToken;
@@ -30,6 +31,11 @@ import java.util.concurrent.CompletionStage;
 abstract class IcebergRefreshTokenFlow extends AbstractFlow implements RefreshFlow {
 
   interface Builder extends AbstractFlow.Builder<IcebergRefreshTokenFlow, Builder> {}
+
+  @Override
+  public GrantType getGrantType() {
+    return GrantType.TOKEN_EXCHANGE;
+  }
 
   @Override
   public CompletionStage<Tokens> refreshTokens(Tokens currentTokens) {
@@ -48,5 +54,10 @@ abstract class IcebergRefreshTokenFlow extends AbstractFlow implements RefreshFl
             .requestedTokenType(getSpec().getTokenExchangeConfig().getRequestedTokenType());
 
     return invokeTokenEndpoint(currentTokens, request);
+  }
+
+  @Override
+  public boolean requiresRefreshToken() {
+    return false;
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlow.java
@@ -16,6 +16,7 @@
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
 import com.dremio.iceberg.authmgr.oauth2.config.Secret;
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.rest.PasswordTokenRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
@@ -30,6 +31,11 @@ import java.util.concurrent.CompletionStage;
 abstract class PasswordFlow extends AbstractFlow implements InitialFlow {
 
   interface Builder extends AbstractFlow.Builder<PasswordFlow, Builder> {}
+
+  @Override
+  public GrantType getGrantType() {
+    return GrantType.PASSWORD;
+  }
 
   @Override
   public CompletionStage<Tokens> fetchNewTokens() {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshFlow.java
@@ -15,6 +15,7 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import java.util.concurrent.CompletionStage;
 
@@ -31,4 +32,14 @@ public interface RefreshFlow extends Flow {
    * @return A future that completes when the tokens are refreshed.
    */
   CompletionStage<Tokens> refreshTokens(Tokens currentTokens);
+
+  @Override
+  default GrantType getGrantType() {
+    return GrantType.REFRESH_TOKEN;
+  }
+
+  /** Returns true if this flow requires a refresh token to be present in the current tokens. */
+  default boolean requiresRefreshToken() {
+    return true;
+  }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
@@ -15,6 +15,7 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import com.dremio.iceberg.authmgr.oauth2.grant.GrantType;
 import com.dremio.iceberg.authmgr.oauth2.rest.TokenExchangeRequest;
 import com.dremio.iceberg.authmgr.oauth2.token.Tokens;
 import com.dremio.iceberg.authmgr.oauth2.token.TypedToken;
@@ -36,6 +37,11 @@ abstract class TokenExchangeFlow extends AbstractFlow implements InitialFlow {
 
     @CanIgnoreReturnValue
     Builder actorTokenStage(CompletionStage<TypedToken> actorTokenStage);
+  }
+
+  @Override
+  public GrantType getGrantType() {
+    return GrantType.TOKEN_EXCHANGE;
   }
 
   abstract CompletionStage<TypedToken> subjectTokenStage();


### PR DESCRIPTION
Small change to make the agent agnostic of OAuth2 dialects. No functional change.