### PR TITLE
fix(release): Temporarily disable writes to issues and discussions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,9 @@ on:
 permissions:
   contents: write
   packages: write
-  issues: write
-  discussions: write
+  # TODO enable
+  # issues: write
+  # discussions: write
 
 jobs:
   release:

--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -125,13 +125,15 @@ jreleaser {
         name.set("{{projectVersionNumber}}")
       }
       issues {
-        enabled.set(true)
+        // TODO enable when the CI user has permissions to close issues
+        enabled.set(false)
         comment.set(
           "🎉 This issue has been resolved in version {{projectVersionNumber}} ([Release Notes]({{releaseNotesUrl}}))"
         )
         applyMilestone.set(Apply.ALWAYS)
       }
-      discussionCategoryName.set("Announcements")
+      // TODO enable when the CI user has permissions to write to discussions
+      discussionCategoryName.set("")
       changelog {
         links.set(true)
         skipMergeCommits.set(true)

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -20,6 +20,6 @@
 [libraries]
 errorprone = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version = "4.1.0" }
 idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext", version = "1.1.10" }
-jreleaser = { module = "org.jreleaser:jreleaser-gradle-plugin", version = "1.18.0" }
+jreleaser = { module = "org.jreleaser:jreleaser-gradle-plugin", version = "1.19.0" }
 shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "8.3.6" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.0.2" }


### PR DESCRIPTION
Writing to issues and discussions is currently not possible from the GitHub token that runs release jobs.