### PR TITLE
fix(release): Fix OAuth2 Runtime Maven publication

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
@@ -49,7 +49,8 @@ afterEvaluate {
         create<MavenPublication>("staging-maven") {
           if (project.plugins.hasPlugin("com.gradleup.shadow")) {
             from(components["shadow"])
-            // Shadow component doesn't include javadoc and sources jars by default, so add them explicitly
+            // Shadow component doesn't include javadoc and sources jars by default, so add them
+            // explicitly
             artifact(tasks.named("javadocJar"))
             artifact(tasks.named("sourcesJar"))
           } else {


### PR DESCRIPTION
This change fixes the Maven publication for components using the Shadow plugin, such as OAuth2 Runtime (this is the only one in fact).

Since shadow components to not include the javadoc and sources jars by default, we do it manually when creating the publication.