### PR TITLE
chore(tests): Increase timeout of lifecycle methods

### DIFF
--- a/oauth2/core/src/intTest/resources/junit-platform.properties
+++ b/oauth2/core/src/intTest/resources/junit-platform.properties
@@ -15,4 +15,5 @@
 #
 
 junit.jupiter.execution.timeout.default=60 s
+junit.jupiter.execution.timeout.lifecycle.method.default=120 s
 junit.jupiter.execution.timeout.threaddump.enabled=true

--- a/oauth2/core/src/longTest/resources/junit-platform.properties
+++ b/oauth2/core/src/longTest/resources/junit-platform.properties
@@ -15,4 +15,5 @@
 #
 
 junit.jupiter.execution.timeout.default=60 s
+junit.jupiter.execution.timeout.lifecycle.method.default=120 s
 junit.jupiter.execution.timeout.threaddump.enabled=true

--- a/oauth2/runtime-flink-tests/src/intTest/resources/junit-platform.properties
+++ b/oauth2/runtime-flink-tests/src/intTest/resources/junit-platform.properties
@@ -15,4 +15,5 @@
 #
 
 junit.jupiter.execution.timeout.default=60 s
+junit.jupiter.execution.timeout.lifecycle.method.default=120 s
 junit.jupiter.execution.timeout.threaddump.enabled=true

--- a/oauth2/runtime-spark-tests/src/intTest/resources/junit-platform.properties
+++ b/oauth2/runtime-spark-tests/src/intTest/resources/junit-platform.properties
@@ -15,4 +15,5 @@
 #
 
 junit.jupiter.execution.timeout.default=60 s
+junit.jupiter.execution.timeout.lifecycle.method.default=120 s
 junit.jupiter.execution.timeout.threaddump.enabled=true


### PR DESCRIPTION
The new timeout is more comfortable for tests that need to pull Docker images.