### PR TITLE
feat(build): Generate distribution LICENSE and NOTICE files

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   implementation(gradleKotlinDsl())
   implementation(baselibs.errorprone)
   implementation(baselibs.idea.ext)
+  implementation(baselibs.license.report)
   implementation(baselibs.shadow)
   implementation(baselibs.spotless)
   implementation(baselibs.jreleaser)

--- a/build-logic/src/main/kotlin/authmgr-bundle.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-bundle.gradle.kts
@@ -15,9 +15,21 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.ApacheNoticeResourceTransformer
+import com.github.jk1.license.License
+import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ModuleData
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.filter.SpdxLicenseBundleNormalizer
+import com.github.jk1.license.render.ReportRenderer
+import java.io.FileWriter
+import java.time.LocalDate
+import kotlin.collections.forEach
+import kotlin.jvm.java
 
 plugins {
   id("com.gradleup.shadow")
+  id("com.github.jk1.dependency-license-report")
   id("authmgr-java")
 }
 
@@ -61,10 +73,12 @@ dependencies {
 val shadowJar = tasks.named<ShadowJar>("shadowJar")
 
 shadowJar.configure {
+  dependsOn("checkLicense")
   isZip64 = true
   outputs.cacheIf { false } // do not cache uber/shaded jars
   mergeServiceFiles()
   archiveClassifier = "" // replace original jar
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE
   // relocations specific to the AuthManager dependencies
   relocate("com.nimbusds", "com.dremio.iceberg.authmgr.shaded.com.nimbusds")
   relocate("net.minidev", "com.dremio.iceberg.authmgr.shaded.net.minidev")
@@ -78,6 +92,16 @@ shadowJar.configure {
   exclude("META-INF/maven/com.google.code.gson/**")
   exclude("META-INF/proguard/**")
   exclude("iso3166_*.properties")
+  // include binary distribution LICENSE file, excluding other LICENSE files
+  exclude("META-INF/LICENSE", "META-INF/LICENSE.txt")
+  from("$projectDir/build/reports/license/LICENSE") { into("META-INF") }
+  // include project's NOTICE then merge all NOTICE files
+  from("${rootDir}/NOTICE") { into("META-INF") }
+  val noticeResourceTransformer = ApacheNoticeResourceTransformer()
+  noticeResourceTransformer.projectName = "Dremio AuthManager for Apache Iceberg"
+  noticeResourceTransformer.copyright = "Copyright (c) ${LocalDate.now().year} Dremio"
+  noticeResourceTransformer.inceptionYear = "2025"
+  transform(noticeResourceTransformer)
   // exclude smallrye-config from minimizing since it has generated code
   minimize { exclude(dependency("io.smallrye.config:smallrye-config")) }
 }
@@ -87,12 +111,14 @@ tasks.named("assemble").configure { dependsOn("shadowJar") }
 // Configure the source jar to copy from the core project's source jar
 tasks.named<Jar>("sourcesJar") {
   dependsOn(":authmgr-oauth2-core:sourcesJar")
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE // LICENSE files may be duplicated
   from({ coreSources.incoming.artifactView { lenient(true) }.files.map { zipTree(it) } })
 }
 
 // Configure the javadoc jar to copy from the core project's javadoc jar
 tasks.named<Jar>("javadocJar") {
   dependsOn(":authmgr-oauth2-core:javadocJar")
+  duplicatesStrategy = DuplicatesStrategy.INCLUDE // LICENSE files may be duplicated
   from({ coreJavadoc.incoming.artifactView { lenient(true) }.files.map { zipTree(it) } })
 }
 
@@ -101,3 +127,83 @@ tasks.withType<Javadoc> { enabled = false }
 
 // We're replacing the "original jar" with the uber-jar.
 tasks.named("jar") { enabled = false }
+
+licenseReport {
+  outputDir = "$projectDir/build/reports/license"
+  configurations = arrayOf("runtimeClasspath")
+  filters = arrayOf(SpdxLicenseBundleNormalizer())
+  allowedLicensesFile =
+    rootProject.projectDir.resolve("gradle/license/allowed-licenses.json5").absoluteFile
+  renderers = arrayOf<ReportRenderer>(BundleLicenseGenerator())
+  excludeOwnGroup = true
+}
+
+tasks.named("checkLicense") {
+  inputs
+    .files(rootProject.projectDir.resolve("gradle/license/allowed-licenses.json5"))
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
+class BundleLicenseGenerator() : ReportRenderer {
+
+  override fun render(data: ProjectData?) {
+    if (data == null) return
+
+    val config = data.project.extensions.getByType(LicenseReportExtension::class.java)
+    val outputDir = File(config.outputDir)
+    if (!outputDir.exists()) {
+      outputDir.mkdirs()
+    }
+
+    val outputFile = File(outputDir, "LICENSE")
+    FileWriter(outputFile).use { writer ->
+
+      // Write the full Apache License 2.0 text
+      writer.write(data.project.rootProject.file("LICENSE").readText())
+
+      // Write third-party dependencies section
+      writer.write(
+        "\n================================================================================\n\n"
+      )
+      writer.write("THIRD-PARTY DEPENDENCIES\n\n")
+      writer.write("This product includes software developed by the following third parties:\n\n")
+
+      val dependenciesByGroup = groupDependencies(data)
+
+      dependenciesByGroup.forEach { (group, modules) ->
+        writer.write(
+          "--------------------------------------------------------------------------------\n\n"
+        )
+
+        writer.write("Group: $group\n")
+        writer.write("\nArtifacts:\n")
+        modules.forEach { module -> writer.write("- $group:${module.name}:${module.version}\n") }
+
+        val licenseInfo = getLicenseInfo(modules)
+
+        writer.write("\nLicenses:\n")
+        licenseInfo.forEach { entry ->
+          writer.write("- ${entry.key}${entry.value?.url?.let { " ($it)" }}\n")
+        }
+
+        writer.write("\n")
+      }
+    }
+  }
+
+  private fun groupDependencies(data: ProjectData): Map<String, List<ModuleData>> {
+    return data.allDependencies
+      .filter { it.group.isNotEmpty() && it.name.isNotEmpty() && it.hasArtifactFile }
+      .groupBy { it.group }
+      .toSortedMap()
+  }
+
+  private fun getLicenseInfo(modules: List<ModuleData>): Map<String?, License?> {
+    val pomLicenses =
+      modules.flatMap { it.poms }.map { it.licenses }.flatten().associateBy { it.name }
+    if (pomLicenses.isEmpty()) {
+      throw GradleException("Missing license information in group: ${modules.first().group}")
+    }
+    return pomLicenses
+  }
+}

--- a/build-logic/src/main/kotlin/authmgr-java.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-java.gradle.kts
@@ -75,6 +75,9 @@ java {
 }
 
 tasks.withType<Jar>().configureEach {
+  from(rootProject.file("LICENSE")) { into("META-INF") }
+  from(rootProject.file("NOTICE")) { into("META-INF") }
+
   manifest {
     attributes(
       "Implementation-Title" to project.name,

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -21,5 +21,6 @@
 errorprone = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version = "4.3.0" }
 idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext", version = "1.2" }
 jreleaser = { module = "org.jreleaser:jreleaser-gradle-plugin", version = "1.19.0" }
+license-report = { module = "com.github.jk1:gradle-license-report", version = "2.9" }
 shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "8.3.8" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "7.2.1" }

--- a/gradle/license/allowed-licenses.json5
+++ b/gradle/license/allowed-licenses.json5
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "allowedLicenses": [
+
+    // See https://www.apache.org/legal/resolved.html
+
+    // Category A
+    { "moduleLicense" : "Apache-1.0" },
+    { "moduleLicense" : "Apache-2.0" },
+    { "moduleLicense" : "BSD-2.Clause" },
+    { "moduleLicense" : "BSD-3.Clause" },
+    { "moduleLicense" : "CC0-1.0" },
+    { "moduleLicense" : "MIT" },
+    { "moduleLicense" : "MIT-0" },
+    { "moduleLicense" : "Public-Domain" },
+
+    // Category B
+    { "moduleLicense" : "CDDL-1.0" },
+    { "moduleLicense" : "CDDL-1.1" },
+    { "moduleLicense" : "CPL-1.0" },
+    { "moduleLicense" : "EPL-1.0" },
+    { "moduleLicense" : "EPL-2.0" }
+
+  ]
+}


### PR DESCRIPTION
Fixes #11.
Fixes #60.

This commit introduces the following changes:

- All non-shaded artifacts produced by the build now contain the project's license text under `META-INF/LICENSE`.
- All non-shaded artifacts produced by the build now contain the project's NOTICE file under `META-INF/NOTICE`.
- The `authmgr-oauth2-runtime` binary distribution uber-jar includes:
  - A special `LICENSE` file including this project's license, followed by license mentions for all dependencies;
  - A `NOTICE` file including the contents of this project's `NOTICE`, and all `NOTICE` and `NOTICE.txt` files from dependencies.
- The `com.github.jk1.dependency-license-report` plugin has been added in order to generate the extended `LICENSE` file for uber-jars.