### PR TITLE
chore(build): Remove Jackson dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,6 @@ immutables-builder = { module = "org.immutables:builder", version.ref = "immutab
 immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 immutables-value-processor = { module = "org.immutables:value-processor", version.ref = "immutables" }
 iceberg-bom = { module = "org.apache.iceberg:iceberg-bom", version.ref = "iceberg" }
-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.19.2" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.13.4" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version = "26.0.6" }

--- a/oauth2/core/build.gradle.kts
+++ b/oauth2/core/build.gradle.kts
@@ -40,11 +40,6 @@ dependencies {
   implementation(libs.slf4j.api)
   implementation(libs.caffeine)
 
-  implementation(platform(libs.jackson.bom))
-  implementation("com.fasterxml.jackson.core:jackson-annotations")
-  implementation("com.fasterxml.jackson.core:jackson-core")
-  implementation("com.fasterxml.jackson.core:jackson-databind")
-
   compileOnly(libs.jakarta.annotation.api)
   compileOnly(libs.errorprone.annotations)
 
@@ -57,10 +52,6 @@ dependencies {
 
   testFixturesApi(platform(libs.junit.bom))
   testFixturesApi("org.junit.jupiter:junit-jupiter")
-
-  testFixturesApi(platform(libs.jackson.bom))
-  testFixturesApi("com.fasterxml.jackson.core:jackson-core")
-  testFixturesApi("com.fasterxml.jackson.core:jackson-databind")
 
   testFixturesApi(libs.assertj.core)
   testFixturesApi(libs.mockito.core)


### PR DESCRIPTION
With the switch to Nimbus, Jackson became unused.