### PR TITLE
chore(build): exclude unnecessary Nimbus files from runtime jar

### DIFF
--- a/oauth2/runtime/build.gradle.kts
+++ b/oauth2/runtime/build.gradle.kts
@@ -74,8 +74,11 @@ tasks.shadowJar {
   relocate("com.fasterxml.jackson", "org.apache.iceberg.shaded.com.fasterxml.jackson")
   relocate("com.github.benmanes", "org.apache.iceberg.shaded.com.github.benmanes")
   relocate("org.apache.hc", "org.apache.iceberg.shaded.org.apache.hc")
-  // exclude unwanted files
+  // exclude module-info.class files
   exclude("META-INF/**/module-info.class")
+  // exclude unnecessary files from Nimbus OIDC SDK and JoSE JWT
+  exclude("META-INF/maven/com.github.stephenc.jcip/**")
+  exclude("META-INF/maven/com.google.code.gson/**")
   exclude("META-INF/proguard/**")
   exclude("iso3166_*.properties")
   // exclude smallrye-config from minimizing since it has generated code


### PR DESCRIPTION
The excluded META-INF files are brought by transitive optional dependencies of Nimbus JoSE JWT. Excluding the dependencies themselves doesn't help.