### PR TITLE
fix(oauth): Include extra parameters in authorization URI

### DIFF
--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AuthorizationCodeExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AuthorizationCodeExpectation.java
@@ -113,7 +113,8 @@ public abstract class AuthorizationCodeExpectation extends InitialTokenFetchExpe
             .withQueryStringParameter("scope", String.format("(%s|%s)", SCOPE1, SCOPE2))
             .withQueryStringParameter(
                 "redirect_uri", "http://localhost:\\d+/iceberg-auth-manager-\\d+(-\\w+)?/auth")
-            .withQueryStringParameter("state", "[a-zA-Z0-9-._~]+");
+            .withQueryStringParameter("state", "[a-zA-Z0-9-._~]+")
+            .withQueryStringParameter("(extra1|extra2)", "(value1|value2)");
     if (getTestEnvironment().isPkceEnabled()) {
       request.withQueryStringParameter("code_challenge", "[a-zA-Z0-9-._~]+");
       request.withQueryStringParameter(


### PR DESCRIPTION
This fix addresses an issue where the `extra-params` configuration option was not being properly included in the authorization URI. Consequently, users, particularly Auth0 users passing the `audience` parameter, were receiving opaque tokens instead of JWTs.

This fix also addresses an issue where the redirect URI was being provided in full; in these cases, the flow would throw an exception when starting the server.