### PR TITLE
feat(oauth): Support Iceberg 1.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,6 @@ org.gradle.jvmargs=-Xms2g -Xmx4g -XX:MaxMetaspaceSize=768m
 # Matrix testing configuration for integration tests
 # Comma-separated list of versions to test against
 # The last version in the list is the default and will be used for the main intTest task
-authmgr.test.iceberg.versions=1.9.1,1.9.2
-authmgr.test.spark.versions=3.5.5,3.5.6
-authmgr.test.flink.versions=1.20.1,1.20.2
+authmgr.test.iceberg.versions=1.9.2,1.10.0
+authmgr.test.spark.versions=3.5.6,4.0.1
+authmgr.test.flink.versions=1.20.2,2.0.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@
 [versions]
 errorprone = "2.41.0"
 hadoop = "3.4.1"
-iceberg = "1.9.2" # When updating iceberg version, also update the iceberg test versions in gradle.properties
+iceberg = "1.10.0" # When updating iceberg version, also update the iceberg test versions in gradle.properties
 immutables = "2.11.1"
 mockito = "5.18.0"
 mockserver = "5.15.0"

--- a/oauth2/runtime-flink-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/flink/FlinkPolarisS3ITBase.java
+++ b/oauth2/runtime-flink-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/flink/FlinkPolarisS3ITBase.java
@@ -50,13 +50,7 @@ public abstract class FlinkPolarisS3ITBase {
   public void recordExpectedVersions() {
     var expectedIcebergVersion = System.getProperty("authmgr.test.iceberg.version");
     var actualIcebergVersion = IcebergBuild.version();
-    if (actualIcebergVersion.equals("unspecified")) {
-      // Iceberg 1.9.0 returns "unspecified" :shrug:
-      var icebergTag = IcebergBuild.gitTags().get(0);
-      assertThat(icebergTag).startsWith("apache-iceberg-" + expectedIcebergVersion);
-    } else {
-      assertThat(actualIcebergVersion).startsWith(expectedIcebergVersion);
-    }
+    assertThat(actualIcebergVersion).startsWith(expectedIcebergVersion);
     // TODO how to check Flink version? GlobalConfiguration.loadConfiguration() doesn't work
   }
 

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkNessieKeycloakS3IT.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkNessieKeycloakS3IT.java
@@ -85,7 +85,7 @@ public class SparkNessieKeycloakS3IT extends SparkNessieS3ITBase {
 
   @AfterAll
   @Override
-  public void stopAllContainers() {
+  public void stopAllContainers() throws Exception {
     var keycloak = this.keycloak;
     try (keycloak) {
       super.stopAllContainers();

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkNessieS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkNessieS3ITBase.java
@@ -47,7 +47,7 @@ public abstract class SparkNessieS3ITBase extends SparkS3ITBase {
 
   @AfterAll
   @Override
-  public void stopAllContainers() {
+  public void stopAllContainers() throws Exception {
     var nessie = this.nessie;
     try (nessie) {
       super.stopAllContainers();

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisKeycloakS3IT.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisKeycloakS3IT.java
@@ -73,7 +73,7 @@ public class SparkPolarisKeycloakS3IT extends SparkPolarisS3ITBase {
 
   @AfterAll
   @Override
-  public void stopAllContainers() {
+  public void stopAllContainers() throws Exception {
     var keycloak = this.keycloak;
     try (keycloak) {
       super.stopAllContainers();

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkPolarisS3ITBase.java
@@ -91,7 +91,7 @@ public abstract class SparkPolarisS3ITBase extends SparkS3ITBase {
 
   @AfterAll
   @Override
-  public void stopAllContainers() {
+  public void stopAllContainers() throws Exception {
     var polaris = this.polaris;
     try (polaris) {
       super.stopAllContainers();

--- a/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkS3ITBase.java
+++ b/oauth2/runtime-spark-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/spark/SparkS3ITBase.java
@@ -123,7 +123,7 @@ public abstract class SparkS3ITBase {
   }
 
   @AfterAll
-  public void stopAllContainers() {
+  public void stopAllContainers() throws Exception {
     var s3 = this.s3;
     try (s3) {
       if (spark != null) {


### PR DESCRIPTION
Fixes #127.

Summary of changes:

- Updated `OAuth2Manager` to use `ThreadPools.authRefreshPool()` if available
- Updated Flink & Spark tests to run against Iceberg 1.10.