### PR TITLE
fix(build): Fix incorrect Maven scopes in published POMs

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
@@ -49,13 +49,24 @@ afterEvaluate {
             // explicitly
             artifact(tasks.named("javadocJar"))
             artifact(tasks.named("sourcesJar"))
-          } else {
-            from(components.firstOrNull { it.name == "java" })
+          } else if (project.plugins.hasPlugin("authmgr-java")) {
+            val javaComponent = components["java"] as AdhocComponentWithVariants
+            from(javaComponent)
+            if (project.plugins.hasPlugin("authmgr-java-testing")) {
+              // Do not include testFixtures in publication as they appear in compile scope
+              // https://github.com/gradle/gradle/issues/14936
+              javaComponent.withVariantsFromConfiguration(
+                configurations["testFixturesApiElements"]
+              ) {
+                skip()
+              }
+              javaComponent.withVariantsFromConfiguration(
+                configurations["testFixturesRuntimeElements"]
+              ) {
+                skip()
+              }
+            }
           }
-
-          // Suppress test fixtures capability warnings
-          suppressPomMetadataWarningsFor("testFixturesApiElements")
-          suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
 
           pom {
             // Use the mavenName property if it exists, otherwise use a default

--- a/oauth2/core/build.gradle.kts
+++ b/oauth2/core/build.gradle.kts
@@ -36,14 +36,14 @@ val docs by
   }
 
 dependencies {
-  implementation(platform(libs.iceberg.bom))
-  implementation("org.apache.iceberg:iceberg-api")
-  implementation("org.apache.iceberg:iceberg-core")
+  api(platform(libs.iceberg.bom))
+  api("org.apache.iceberg:iceberg-api")
+  api("org.apache.iceberg:iceberg-core")
 
-  implementation(libs.nimbus.oauth2.oidc.sdk) {
+  api(libs.nimbus.oauth2.oidc.sdk) {
     exclude(group = "com.github.stephenc.jcip", module = "jcip-annotations")
   }
-  implementation(libs.nimbus.jose.jwt)
+  api(libs.nimbus.jose.jwt)
 
   implementation(libs.httpclient5)
 


### PR DESCRIPTION
This changes fixes 2 items:

- Required dependencies were being included in runtime scope rather than compile scope. See https://stackoverflow.com/questions/72952154/gradle-maven-publish-dependency-scope.
- Test fixture dependencies were being included in compile scope rather than test scope. See https://github.com/gradle/gradle/issues/14936.