### PR TITLE
chore(build): Re-introduce the "files" section in JReleaser config

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -28,6 +28,9 @@ jreleaser {
   val excludedProjects =
     setOf("authmgr-oauth2-flink-tests", "authmgr-oauth2-spark-tests", "authmgr-oauth2-kafka-tests")
 
+  // Projects to include as release assets in the GitHub Release page
+  val assetsProjects = setOf("authmgr-oauth2-runtime", "authmgr-oauth2-standalone")
+
   project {
     name.set("Dremio Iceberg AuthManager")
     description.set("Dremio AuthManager for Apache Iceberg")
@@ -45,15 +48,18 @@ jreleaser {
   // Required to upload release assets to the GitHub Release page
   // see https://github.com/jreleaser/jreleaser/issues/1627
   files {
-    subprojects.forEach { project ->
-      if (project.name !in excludedProjects) {
-        glob {
-          pattern.set(
-            project.layout.buildDirectory.dir("libs").get().asFile.absolutePath + "/**.jar"
+    subprojects
+      .filter { it.name in assetsProjects }
+      .forEach { project ->
+        artifact {
+          path.set(
+            project.layout.buildDirectory
+              .dir("libs")
+              .get()
+              .file("${project.name}-${rootProject.version}.jar")
           )
         }
       }
-    }
   }
 
   signing {

--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -42,6 +42,20 @@ jreleaser {
     copyright = "Copyright (c) ${LocalDate.now().year} Dremio"
   }
 
+  // Required to upload release assets to the GitHub Release page
+  // see https://github.com/jreleaser/jreleaser/issues/1627
+  files {
+    subprojects.forEach { project ->
+      if (project.name !in excludedProjects) {
+        glob {
+          pattern.set(
+            project.layout.buildDirectory.dir("libs").get().asFile.absolutePath + "/**.jar"
+          )
+        }
+      }
+    }
+  }
+
   signing {
     active.set(Active.ALWAYS)
     verify.set(false) // requires the GPG public key to be set up


### PR DESCRIPTION
The `files` section is not required to deploy artifacts to Sonatype, but it is in fact required to define assets to include in the GitHub release.

This change partially reverts commit ea7d92096adc784f1bd606203b7fab33ba1ad594.