### PR TITLE
fix(build): Fix Maven publication & JReleaser configuration

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-maven.gradle.kts
@@ -39,114 +39,105 @@ if (project.hasProperty("release")) {
 
 // Use afterEvaluate to ensure properties are accessed after they've been set
 afterEvaluate {
-
-  // Projects to exclude from publication and BOM
-  val excludedProjects =
-    setOf("authmgr-oauth2-flink-tests", "authmgr-oauth2-spark-tests", "authmgr-oauth2-kafka-tests")
-
   publishing {
     publications {
 
-      // Only create maven publication for projects that should be published
-      if (project.name !in excludedProjects) {
+      // This publication is used for staging and deployment to Maven Central by JReleaser
+      create<MavenPublication>("maven") {
+        if (project.plugins.hasPlugin("authmgr-bundle")) {
+          from(components["shadow"])
+          // Shadow component doesn't include javadoc and sources jars by default, so add them
+          // explicitly
+          artifact(tasks.named("javadocJar"))
+          artifact(tasks.named("sourcesJar"))
+        } else if (project.plugins.hasPlugin("authmgr-java")) {
+          val javaComponent = components["java"] as AdhocComponentWithVariants
+          from(javaComponent)
+          if (project.plugins.hasPlugin("authmgr-java-testing")) {
+            // Do not include testFixtures in publication as they appear in compile scope
+            // https://github.com/gradle/gradle/issues/14936
+            javaComponent.withVariantsFromConfiguration(configurations["testFixturesApiElements"]) {
+              skip()
+            }
+            javaComponent.withVariantsFromConfiguration(
+              configurations["testFixturesRuntimeElements"]
+            ) {
+              skip()
+            }
+          }
+        }
 
-        // This publication is used for staging and deployment to Maven Central by JReleaser
-        create<MavenPublication>("maven") {
-          if (project.plugins.hasPlugin("authmgr-bundle")) {
-            from(components["shadow"])
-            // Shadow component doesn't include javadoc and sources jars by default, so add them
-            // explicitly
-            artifact(tasks.named("javadocJar"))
-            artifact(tasks.named("sourcesJar"))
-          } else if (project.plugins.hasPlugin("authmgr-java")) {
-            val javaComponent = components["java"] as AdhocComponentWithVariants
-            from(javaComponent)
-            if (project.plugins.hasPlugin("authmgr-java-testing")) {
-              // Do not include testFixtures in publication as they appear in compile scope
-              // https://github.com/gradle/gradle/issues/14936
-              javaComponent.withVariantsFromConfiguration(
-                configurations["testFixturesApiElements"]
-              ) {
-                skip()
-              }
-              javaComponent.withVariantsFromConfiguration(
-                configurations["testFixturesRuntimeElements"]
-              ) {
-                skip()
-              }
+        pom {
+          // Use the mavenName property if it exists, otherwise use a default
+          name =
+            if (project.hasProperty("mavenName")) {
+              project.property("mavenName").toString()
+            } else {
+              "Auth Manager for Apache Iceberg - ${project.name}"
+            }
+
+          description = project.description
+
+          url.set("https://github.com/dremio/iceberg-auth-manager")
+          inceptionYear = "2025"
+
+          licenses {
+            license {
+              name = "Apache-2.0"
+              url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
             }
           }
 
-          pom {
-            // Use the mavenName property if it exists, otherwise use a default
-            name =
-              if (project.hasProperty("mavenName")) {
-                project.property("mavenName").toString()
-              } else {
-                "Auth Manager for Apache Iceberg - ${project.name}"
-              }
-
-            description = project.description
-
-            url.set("https://github.com/dremio/iceberg-auth-manager")
-            inceptionYear = "2025"
-
-            licenses {
-              license {
-                name = "Apache-2.0"
-                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-              }
+          developers {
+            developer {
+              id = "dremio"
+              name = "Dremio"
+              email = "oss@dremio.com"
+              organization = "Dremio Corporation"
+              organizationUrl = "https://www.dremio.com"
             }
+          }
 
-            developers {
-              developer {
-                id = "dremio"
-                name = "Dremio"
-                email = "oss@dremio.com"
-                organization = "Dremio Corporation"
-                organizationUrl = "https://www.dremio.com"
-              }
+          scm {
+            connection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
+            developerConnection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
+            url = "https://github.com/dremio/iceberg-auth-manager"
+            if (!version.endsWith("-SNAPSHOT")) {
+              tag = "authmgr-$version"
             }
+          }
 
-            scm {
-              connection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
-              developerConnection = "scm:git:git://github.com/dremio/iceberg-auth-manager.git"
-              url = "https://github.com/dremio/iceberg-auth-manager"
-              if (!version.endsWith("-SNAPSHOT")) {
-                tag = "authmgr-$version"
-              }
-            }
-
-            if (project == project.rootProject) {
-              withXml {
-                val modules = asNode().appendNode("modules")
-                subprojects.forEach { subproject ->
-                  if (subproject.name !in excludedProjects) {
-                    modules.appendNode("module", subproject.name)
-                  }
+          if (project == project.rootProject) {
+            withXml {
+              val modules = asNode().appendNode("modules")
+              subprojects.forEach { subproject ->
+                if (subproject.plugins.hasPlugin("authmgr-maven")) {
+                  modules.appendNode("module", subproject.name)
                 }
               }
-            } else {
-              withXml {
-                val parentNode = asNode().appendNode("parent")
-                parentNode.appendNode("groupId", project.rootProject.group)
-                parentNode.appendNode("artifactId", project.rootProject.name)
-                parentNode.appendNode("version", project.rootProject.version)
-              }
-              if (project.name == "authmgr-bom") {
-                pom.withXml {
-                  val dependencies =
-                    asNode().appendNode("dependencyManagement").appendNode("dependencies")
+            }
+          } else {
+            withXml {
+              val parentNode = asNode().appendNode("parent")
+              parentNode.appendNode("groupId", project.rootProject.group)
+              parentNode.appendNode("artifactId", project.rootProject.name)
+              parentNode.appendNode("version", project.rootProject.version)
+            }
+            if (project.name == "authmgr-bom") {
+              pom.withXml {
+                val dependencies =
+                  asNode().appendNode("dependencyManagement").appendNode("dependencies")
 
-                  // Add all project modules to the BOM
-                  rootProject.subprojects.forEach { subproject ->
-                    // Skip the BOM itself and excluded projects
-                    if (subproject.name != project.name && subproject.name !in excludedProjects) {
-                      dependencies.appendNode("dependency").apply {
-                        appendNode("groupId", subproject.group)
-                        appendNode("artifactId", subproject.name)
-                        appendNode("version", subproject.version)
-                      }
+                // Add all project modules to the BOM
+                rootProject.subprojects.forEach { subproject ->
+                  // Skip the BOM itself and any projects that don't have the authmgr-maven plugin
+                  if (
+                    subproject.name != project.name && subproject.plugins.hasPlugin("authmgr-maven")
+                  ) {
+                    dependencies.appendNode("dependency").apply {
+                      appendNode("groupId", subproject.group)
+                      appendNode("artifactId", subproject.name)
+                      appendNode("version", subproject.version)
                     }
                   }
                 }


### PR DESCRIPTION
The introduction of a new module recently (`authmgr-oauth2-tests`) broke the Maven publication & JReleaser logic. 

This PR changes the affected plugins, `authmgr-maven` and `authmgr-jreleaser`. Their logic has been simplified and doesn't require anymore to keep lists of projects to include or to exclude.