### PR TITLE
chore(oauth): Let Smallrye Config parse lists

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -383,7 +383,9 @@ A URI that indicates the target service or resource where the client intends to 
 
 ### `rest.auth.oauth2.token-exchange.audience`
 
-The logical name of the target service where the client intends to use the requested security token. This serves a purpose similar to the resource parameter but with the client providing a logical name for the target service. Optional.
+The logical name of the target service where the client intends to use the requested security token. This serves a purpose similar to the resource parameter but with the client providing a logical name for the target service.
+
+Optional. Can be a single value or a comma-separated list of values.
 
 ## Client Assertion Settings
 

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtils.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtils.java
@@ -21,7 +21,6 @@ import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class ConfigUtils {
 
@@ -58,14 +57,6 @@ public final class ConfigUtils {
   public static boolean requiresUserInteraction(GrantType grantType) {
     return grantType.equals(GrantType.AUTHORIZATION_CODE)
         || grantType.equals(GrantType.DEVICE_CODE);
-  }
-
-  public static List<String> parseCommaSeparatedList(String text) {
-    if (text == null || text.isBlank()) {
-      return List.of();
-    }
-    String[] parts = text.trim().split(",");
-    return Stream.of(parts).map(String::trim).collect(Collectors.toList());
   }
 
   public static Map<String, String> prefixedMap(Map<String, String> properties, String prefix) {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/HttpConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/HttpConfig.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -128,7 +129,7 @@ public interface HttpConfig {
    * default}.
    */
   @WithName(SSL_PROTOCOLS)
-  Optional<String> getSslProtocols();
+  Optional<List<String>> getSslProtocols();
 
   /**
    * A comma-separated list of SSL cipher suites to use for HTTPS requests. Optional, defaults to
@@ -138,7 +139,7 @@ public interface HttpConfig {
    * default}.
    */
   @WithName(SSL_CIPHER_SUITES)
-  Optional<String> getSslCipherSuites();
+  Optional<List<String>> getSslCipherSuites();
 
   /**
    * Whether to enable SSL hostname verification for HTTPS requests.
@@ -251,8 +252,10 @@ public interface HttpConfig {
     getProxyPort().ifPresent(p -> properties.put(PREFIX + '.' + PROXY_PORT, String.valueOf(p)));
     getProxyUsername().ifPresent(u -> properties.put(PREFIX + '.' + PROXY_USERNAME, u));
     getProxyPassword().ifPresent(p -> properties.put(PREFIX + '.' + PROXY_PASSWORD, p));
-    getSslProtocols().ifPresent(p -> properties.put(PREFIX + '.' + SSL_PROTOCOLS, p));
-    getSslCipherSuites().ifPresent(c -> properties.put(PREFIX + '.' + SSL_CIPHER_SUITES, c));
+    getSslProtocols()
+        .ifPresent(p -> properties.put(PREFIX + '.' + SSL_PROTOCOLS, String.join(",", p)));
+    getSslCipherSuites()
+        .ifPresent(c -> properties.put(PREFIX + '.' + SSL_CIPHER_SUITES, String.join(",", c)));
     properties.put(
         PREFIX + '.' + SSL_HOSTNAME_VERIFICATION_ENABLED,
         String.valueOf(isSslHostnameVerificationEnabled()));

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/TokenExchangeConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/TokenExchangeConfig.java
@@ -24,8 +24,10 @@ import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Configuration properties for the <a href="https://datatracker.ietf.org/doc/html/rfc8693">Token
@@ -173,10 +175,12 @@ public interface TokenExchangeConfig {
   /**
    * The logical name of the target service where the client intends to use the requested security
    * token. This serves a purpose similar to the resource parameter but with the client providing a
-   * logical name for the target service. Optional.
+   * logical name for the target service.
+   *
+   * <p>Optional. Can be a single value or a comma-separated list of values.
    */
   @WithName(AUDIENCE)
-  Optional<Audience> getAudience();
+  Optional<List<Audience>> getAudience();
 
   default void validate() {
     ConfigValidator validator = new ConfigValidator();
@@ -206,7 +210,12 @@ public interface TokenExchangeConfig {
     properties.put(
         PREFIX + '.' + REQUESTED_TOKEN_TYPE, getRequestedTokenType().getURI().toString());
     getResource().ifPresent(r -> properties.put(PREFIX + '.' + RESOURCE, r.toString()));
-    getAudience().ifPresent(a -> properties.put(PREFIX + '.' + AUDIENCE, a.getValue()));
+    getAudience()
+        .ifPresent(
+            a ->
+                properties.put(
+                    PREFIX + '.' + AUDIENCE,
+                    a.stream().map(Audience::getValue).collect(Collectors.joining(","))));
     getSubjectTokenConfig()
         .forEach((k, v) -> properties.put(PREFIX + '.' + SUBJECT_TOKEN + '.' + k, v));
     getActorTokenConfig()

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
@@ -19,7 +19,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
-import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.HttpConfig;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import com.google.errorprone.annotations.FormatMethod;
@@ -368,12 +367,10 @@ abstract class AuthorizationCodeFlow extends AbstractFlow {
     HttpConfig httpConfig = getConfig().getHttpConfig();
     httpConfig
         .getSslProtocols()
-        .map(ConfigUtils::parseCommaSeparatedList)
         .map(list -> list.toArray(new String[0]))
         .ifPresent(sslParameters::setProtocols);
     httpConfig
         .getSslCipherSuites()
-        .map(ConfigUtils::parseCommaSeparatedList)
         .map(list -> list.toArray(new String[0]))
         .ifPresent(sslParameters::setCipherSuites);
     params.setSSLParameters(sslParameters);

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
@@ -88,6 +88,6 @@ abstract class TokenExchangeFlow extends AbstractFlow {
                 ? TokenTypeURI.ACCESS_TOKEN
                 : actorToken.getIssuedTokenType(),
         tokenExchangeConfig.getRequestedTokenType(),
-        tokenExchangeConfig.getAudience().map(List::of).orElse(List.of()));
+        tokenExchangeConfig.getAudience().orElseGet(List::of));
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/http/ApacheHttpClient.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/http/ApacheHttpClient.java
@@ -15,7 +15,6 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.http;
 
-import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.HttpConfig;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
@@ -204,12 +203,10 @@ public class ApacheHttpClient implements HttpClient {
             sslContext,
             config
                 .getSslProtocols()
-                .map(ConfigUtils::parseCommaSeparatedList)
                 .map(list -> list.toArray(new String[0]))
                 .orElseGet(HttpsSupport::getSystemProtocols),
             config
                 .getSslCipherSuites()
-                .map(ConfigUtils::parseCommaSeparatedList)
                 .map(list -> list.toArray(new String[0]))
                 .orElseGet(HttpsSupport::getSystemCipherSuits),
             SSLBufferMode.STATIC,

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtilsTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtilsTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class ConfigUtilsTest {
 
@@ -73,12 +72,6 @@ class ConfigUtilsTest {
         Arguments.of(GrantType.REFRESH_TOKEN, false),
         Arguments.of(GrantType.PASSWORD, false),
         Arguments.of(GrantType.TOKEN_EXCHANGE, false));
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"a,b,c", "a, b, c", "  a  , b  , c  "})
-  void parseCommaSeparatedList(String text) {
-    assertThat(ConfigUtils.parseCommaSeparatedList(text)).containsExactly("a", "b", "c");
   }
 
   @Test


### PR DESCRIPTION
Comma-separated lists were being parsed manually. This is not necessary since Smallrye Config can transparently do that.

This change also turns the `rest.auth.oauth2.token-exchange.audience` setting into a multi-valued setting, since Nimbus SDK supports multiple audiences in a token exchange grant.