### PR TITLE
fix(build): Disable closing milestones during release

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -123,17 +123,14 @@ gradle.projectsEvaluated {
 
     release {
       github {
-        releaseName.set("{{projectNameCapitalized}} {{projectVersionNumber}}")
+        releaseName.set("AuthManager {{projectVersionNumber}}")
         repoOwner.set("dremio")
         name.set("iceberg-auth-manager")
         branch.set("main")
         tagName.set("authmgr-{{projectVersion}}")
-        commitAuthor {
-          name.set("{{projectNameCapitalized}} Release Workflow [bot]")
-          email.set("authmgr-release-workflow-noreply@dremio.com")
-        }
         milestone {
-          close.set(true)
+          // TODO enable when the CI user has permissions to close milestones
+          close.set(false)
           name.set("{{projectVersionNumber}}")
         }
         issues {


### PR DESCRIPTION
The CI user doesn't have permissions for that.

This PR also shortens the release name (it didn't fit in the right panel on the repository landing page) and removes the unused `release.github.commitAuthor` section.