### PR TITLE
fix(config): Fix config relocation

### DIFF
--- a/build-logic/src/main/kotlin/authmgr-bundle.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-bundle.gradle.kts
@@ -104,7 +104,12 @@ shadowJar.configure {
   noticeResourceTransformer.inceptionYear = "2025"
   transform(noticeResourceTransformer)
   // exclude smallrye-config from minimizing since it has generated code
-  minimize { exclude(dependency("io.smallrye.config:smallrye-config")) }
+  // exclude jakarta.annotation-api from minimizing since it is referenced only via ldc bytecode
+  // instructions in SmallRyeConfigBuilder, which the shadow minimizer does not detect as reachable.
+  minimize {
+    exclude(dependency("io.smallrye.config:smallrye-config"))
+    exclude(dependency("jakarta.annotation:jakarta.annotation-api"))
+  }
 }
 
 tasks.named("assemble").configure { dependsOn("shadowJar") }

--- a/oauth2/core/build.gradle.kts
+++ b/oauth2/core/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
   implementation(libs.slf4j.api)
   implementation(libs.caffeine)
 
-  compileOnly(libs.jakarta.annotation.api)
+  implementation(libs.jakarta.annotation.api)
   compileOnly(libs.errorprone.annotations)
 
   compileOnly(project(":authmgr-immutables"))

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
@@ -103,6 +103,7 @@ public interface OAuth2Config {
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
             .addDefaultSources()
+            .addDiscoveredInterceptors()
             .withSources(source)
             .withMapping(OAuth2Config.class)
             .build();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
@@ -15,25 +15,112 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.config;
 
-import io.smallrye.config.RelocateConfigSourceInterceptor;
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConfigRelocationInterceptor extends RelocateConfigSourceInterceptor {
+public class ConfigRelocationInterceptor implements ConfigSourceInterceptor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRelocationInterceptor.class);
+  private static final String ROOT_PREFIX = OAuth2Config.PREFIX + '.';
 
-  public ConfigRelocationInterceptor() {
-    super(ConfigRelocationInterceptor::applyRelocations);
+  private static final List<RelocationRule> RELOCATION_RULES =
+      List.of(
+          new RelocationRule(
+              Pattern.compile("\\.callback-"),
+              ".callback.",
+              Pattern.compile("\\.callback\\."),
+              ".callback-"));
+
+  @Override
+  public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {
+    // Only include relocated (canonical) names; filter out legacy aliases
+    // to avoid mapping errors "SRCFG00050 ... does not map to any root"
+    Set<String> canonicalNames = new LinkedHashSet<>();
+    Iterator<String> names = context.iterateNames();
+    while (names.hasNext()) {
+      canonicalNames.add(toCanonicalName(names.next()));
+    }
+    return canonicalNames.iterator();
   }
 
-  private static String applyRelocations(String name) {
-    // rest.auth.oauth2.auth-code.callback- > rest.auth.oauth2.auth-code.callback.
-    if (name.startsWith(AuthorizationCodeConfig.PREFIX + ".callback-")) {
-      String replacement = name.replace(".callback-", ".callback.");
-      LOGGER.warn("Property '{}' is deprecated, use '{}' instead", name, replacement);
-      return replacement;
+  @Override
+  public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
+    if (!name.startsWith(ROOT_PREFIX)) {
+      return context.proceed(name);
     }
-    return name;
+    String canonicalName = toCanonicalName(name);
+    Set<String> candidates = new LinkedHashSet<>();
+    candidates.add(canonicalName);
+    candidates.add(toLegacyName(canonicalName));
+    ConfigValue selected = null;
+    for (String candidate : candidates) {
+      ConfigValue value = context.proceed(candidate);
+      if (value != null
+          && (selected == null
+              || ConfigValue.CONFIG_SOURCE_COMPARATOR.compare(value, selected) >= 0)) {
+        selected = value.withName(canonicalName);
+      }
+    }
+    if (selected != null && !name.equals(canonicalName)) {
+      LOGGER.warn("Property '{}' is deprecated, use '{}' instead", name, canonicalName);
+    }
+    return selected;
+  }
+
+  public static String toCanonicalName(String name) {
+    String canonicalName = name;
+    for (RelocationRule rule : RELOCATION_RULES) {
+      canonicalName = rule.toCanonicalName(canonicalName);
+    }
+    return canonicalName;
+  }
+
+  static String toLegacyName(String name) {
+    String legacyName = name;
+    for (RelocationRule rule : RELOCATION_RULES) {
+      legacyName = rule.toLegacyName(legacyName);
+    }
+    return legacyName;
+  }
+
+  private static final class RelocationRule {
+
+    private final Pattern canonicalPattern;
+    private final String canonicalReplacement;
+
+    private final Pattern legacyPattern;
+    private final String legacyReplacement;
+
+    private RelocationRule(
+        Pattern canonicalPattern,
+        String canonicalReplacement,
+        Pattern legacyPattern,
+        String legacyReplacement) {
+      this.canonicalPattern = canonicalPattern;
+      this.canonicalReplacement = canonicalReplacement;
+      this.legacyPattern = legacyPattern;
+      this.legacyReplacement = legacyReplacement;
+    }
+
+    public String toCanonicalName(String name) {
+      return name.startsWith(ROOT_PREFIX)
+          ? canonicalPattern.matcher(name).replaceAll(canonicalReplacement)
+          : name;
+    }
+
+    public String toLegacyName(String name) {
+      return name.startsWith(ROOT_PREFIX)
+          ? legacyPattern.matcher(name).replaceAll(legacyReplacement)
+          : name;
+    }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ConfigTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ResourceOwnerConfig;
@@ -95,6 +96,66 @@ class OAuth2ConfigTest {
     assertThat(config.getBasicConfig().getScope()).contains(new Scope("test"));
     assertThat(config.getBasicConfig().getExtraRequestParameters()).isEmpty();
     assertThat(config.getBasicConfig().getTimeout()).isEqualTo(Duration.ofMinutes(5));
+  }
+
+  @Test
+  void testLegacyPrefixRelocation() {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(PREFIX + '.' + BasicConfig.ISSUER_URL, "https://example.com")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_ID, "Client")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "w00t")
+            .put(PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.AUTHORIZATION_CODE.getValue())
+            .put(PREFIX + ".auth-code.callback-https", "true")
+            .put(PREFIX + ".auth-code.callback-bind-host", "example.com")
+            .put(PREFIX + ".auth-code.callback-bind-port", "8080")
+            .put(PREFIX + ".auth-code.callback-context-path", "/context")
+            .build();
+    OAuth2Config config = OAuth2Config.from(properties);
+    assertThat(config.getAuthorizationCodeConfig().isCallbackHttps()).isTrue();
+    assertThat(config.getAuthorizationCodeConfig().getCallbackBindHost()).hasValue("example.com");
+    assertThat(config.getAuthorizationCodeConfig().getCallbackBindPort()).hasValue(8080);
+    assertThat(config.getAuthorizationCodeConfig().getCallbackContextPath()).hasValue("/context");
+  }
+
+  @Test
+  @RestoreSystemProperties
+  void testLegacyPrefixRelocationFromSystemProperties() {
+    System.setProperty(PREFIX + '.' + BasicConfig.ISSUER_URL, "https://example.com");
+    System.setProperty(PREFIX + '.' + BasicConfig.CLIENT_ID, "Client");
+    System.setProperty(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "w00t");
+    System.setProperty(
+        PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.AUTHORIZATION_CODE.getValue());
+    System.setProperty(PREFIX + ".auth-code.callback-https", "true");
+    System.setProperty(PREFIX + ".auth-code.callback-bind-host", "example.com");
+    System.setProperty(PREFIX + ".auth-code.callback-bind-port", "8080");
+    System.setProperty(PREFIX + ".auth-code.callback-context-path", "/context");
+    OAuth2Config config = OAuth2Config.from(Map.of());
+    assertThat(config.getAuthorizationCodeConfig().isCallbackHttps()).isTrue();
+    assertThat(config.getAuthorizationCodeConfig().getCallbackBindHost()).hasValue("example.com");
+    assertThat(config.getAuthorizationCodeConfig().getCallbackBindPort()).hasValue(8080);
+    assertThat(config.getAuthorizationCodeConfig().getCallbackContextPath()).hasValue("/context");
+  }
+
+  @Test
+  void testLegacyNestedPrefixRelocation() {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT, "https://example.com/token")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_ID, "Client")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "w00t")
+            .put(PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.TOKEN_EXCHANGE.getValue())
+            .put(
+                "rest.auth.oauth2.token-exchange.subject-token.grant-type",
+                GrantType.AUTHORIZATION_CODE.getValue())
+            .put("rest.auth.oauth2.token-exchange.subject-token.auth-code.callback-https", "true")
+            .build();
+    OAuth2Config config = OAuth2Config.from(properties);
+    assertThat(config.getTokenExchangeConfig().getSubjectTokenConfig())
+        .containsEntry(BasicConfig.GRANT_TYPE, GrantType.AUTHORIZATION_CODE.getValue())
+        .containsEntry(
+            AuthorizationCodeConfig.GROUP_NAME + '.' + AuthorizationCodeConfig.CALLBACK_HTTPS,
+            "true");
   }
 
   @Test

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+import java.util.Map;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ConfigRelocationInterceptorTest {
+
+  @ParameterizedTest
+  @MethodSource
+  void testToCanonicalName(String property, String expected) {
+    assertThat(ConfigRelocationInterceptor.toCanonicalName(property)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> testToCanonicalName() {
+    return Stream.of(
+        Arguments.of(
+            "rest.auth.oauth2.auth-code.callback-https",
+            "rest.auth.oauth2.auth-code.callback.https"),
+        Arguments.of(
+            "rest.auth.oauth2.auth-code.callback-bind-port",
+            "rest.auth.oauth2.auth-code.callback.bind-port"),
+        Arguments.of(
+            "rest.auth.oauth2.auth-code.callback-bind-host",
+            "rest.auth.oauth2.auth-code.callback.bind-host"),
+        Arguments.of("some.other.property", "some.other.property"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testToLegacyName(String property, String expected) {
+    assertThat(ConfigRelocationInterceptor.toLegacyName(property)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> testToLegacyName() {
+    return Stream.of(
+        Arguments.of(
+            "rest.auth.oauth2.auth-code.callback.https",
+            "rest.auth.oauth2.auth-code.callback-https"),
+        Arguments.of(
+            "rest.auth.oauth2.auth-code.callback.bind-port",
+            "rest.auth.oauth2.auth-code.callback-bind-port"),
+        Arguments.of(
+            "rest.auth.oauth2.auth-code.callback.bind-host",
+            "rest.auth.oauth2.auth-code.callback-bind-host"),
+        Arguments.of("some.other.property", "some.other.property"));
+  }
+
+  @Test
+  void testIterateNamesReturnsCanonicalNamesOnly() {
+    SmallRyeConfig config =
+        new SmallRyeConfigBuilder()
+            .setAddDefaultSources(false)
+            .setAddDiscoveredSources(false)
+            .setAddDiscoveredConverters(false)
+            .setAddDiscoveredInterceptors(false)
+            .setAddDiscoveredSecretKeysHandlers(false)
+            .setAddDiscoveredValidator(false)
+            .withInterceptors(new ConfigRelocationInterceptor())
+            .withSources(
+                new MapBackedConfigSource(
+                    "catalog-properties",
+                    Map.of(
+                        "rest.auth.oauth2.auth-code.callback-https", "true",
+                        "rest.auth.oauth2.auth-code.callback-bind-port", "8080",
+                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost"),
+                    1000) {})
+            .build();
+    assertThat(StreamSupport.stream(config.getPropertyNames().spliterator(), false).toList())
+        .containsExactlyInAnyOrder(
+            "rest.auth.oauth2.auth-code.callback.https",
+            "rest.auth.oauth2.auth-code.callback.bind-port",
+            "rest.auth.oauth2.auth-code.callback.bind-host");
+  }
+
+  @Test
+  void testCanonicalLookupsResolveLegacyAliases() {
+    SmallRyeConfig config =
+        new SmallRyeConfigBuilder()
+            .setAddDefaultSources(false)
+            .setAddDiscoveredSources(false)
+            .setAddDiscoveredConverters(false)
+            .setAddDiscoveredInterceptors(false)
+            .setAddDiscoveredSecretKeysHandlers(false)
+            .setAddDiscoveredValidator(false)
+            .withInterceptors(new ConfigRelocationInterceptor())
+            .withSources(
+                new MapBackedConfigSource(
+                    "catalog-properties",
+                    Map.of(
+                        "rest.auth.oauth2.auth-code.callback-https", "true",
+                        "rest.auth.oauth2.auth-code.callback-bind-port", "8080",
+                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost"),
+                    1000) {})
+            .build();
+    assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.https")).isEqualTo("true");
+    assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.bind-port"))
+        .isEqualTo("8080");
+    assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.bind-host"))
+        .isEqualTo("localhost");
+  }
+}


### PR DESCRIPTION
This change fixes 3 bugs related to config relocation:

* Interceptors weren't being added because of a missing call to `.addDiscoveredInterceptors()`.
* SmallRye's `RelocateConfigSourceInterceptor` is not suitable for cases where relocated configs are mapped to Java classes. A whole different approach is needed in order to avoid "does not map to any root" errors on legacy properties. The approach proposed here is vaguely inspired by how Quarkus handles similar cases.
* Jakarta's `jakarta.annotation-api` is required at runtime for the discovery to work properly. This change modifies the dependency from `compileOnly` to `implementation` and makes sure the shadow jar task doesn't evict that dependency due to reachability issues.

This PR is a preparatory work for #208 (support for `jwt-bearer` grants)