### PR TITLE
fix(device-code): extract TokenPoller inner class for thread-safe polling

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
@@ -32,7 +32,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,36 +70,26 @@ abstract class DeviceCodeFlow extends AbstractFlow {
    * endpoint.
    */
   @Value.Default
-  @SuppressWarnings("FutureReturnValueIgnored")
   CompletableFuture<TokensResult> getTokensFuture() {
-    CompletableFuture<TokensResult> future = new CompletableFuture<>();
-    future.whenComplete((tokens, error) -> stopPolling());
-    return future;
+    return new CompletableFuture<>();
   }
 
-  @SuppressWarnings("immutables:incompat")
-  private volatile Duration pollInterval;
-
-  @SuppressWarnings("immutables:incompat")
-  private volatile Future<?> pollFuture;
-
-  private void stopPolling() {
-    LOGGER.debug("[{}] Device Auth Flow: closing", getAgentName());
-    Future<?> pollFuture = this.pollFuture;
-    if (pollFuture != null) {
-      pollFuture.cancel(true);
-    }
-    this.pollFuture = null;
+  @Value.Default
+  TokenPoller getPoller() {
+    return new TokenPoller();
   }
 
   @Override
+  @SuppressWarnings("FutureReturnValueIgnored")
   public CompletionStage<TokensResult> fetchNewTokens() {
     LOGGER.debug("[{}] Device Auth Flow: started", getAgentName());
-    return invokeDeviceAuthorizationEndpoint()
-        .thenCompose(
+    // Return getTokensFuture() directly so that cancelling the result of fetchNewTokens()
+    // will complete getTokensFuture() itself, which triggers stopPolling().
+    // The device authorization endpoint call is a side effect:
+    // on success it starts polling, on failure it completes getTokensFuture() exceptionally.
+    invokeDeviceAuthorizationEndpoint()
+        .thenAccept(
             response -> {
-              pollInterval = getConfig().getDeviceCodeConfig().getPollInterval();
-              checkPollInterval(response.getInterval());
               PrintStream console = getRuntime().getConsole();
               synchronized (console) {
                 console.println();
@@ -110,12 +102,19 @@ abstract class DeviceCodeFlow extends AbstractFlow {
                 console.println();
                 console.flush();
               }
-              pollFuture =
-                  getRuntime()
-                      .getExecutor()
-                      .submit(() -> pollForNewTokens(response.getDeviceCode()));
-              return getTokensFuture();
+              getPoller().start(response.getInterval(), response.getDeviceCode());
+            })
+        .exceptionally(
+            error -> {
+              getTokensFuture()
+                  .completeExceptionally(
+                      error instanceof CompletionException && error.getCause() != null
+                          ? error.getCause()
+                          : error);
+              return null;
             });
+    getTokensFuture().whenComplete((result, error) -> getPoller().stop());
+    return getTokensFuture();
   }
 
   private CompletionStage<DeviceAuthorizationSuccessResponse> invokeDeviceAuthorizationEndpoint() {
@@ -147,17 +146,6 @@ abstract class DeviceCodeFlow extends AbstractFlow {
     }
   }
 
-  private void checkPollInterval(long serverPollInterval) {
-    boolean ignoreServerPollInterval = getConfig().getDeviceCodeConfig().ignoreServerPollInterval();
-    if (!ignoreServerPollInterval && serverPollInterval > pollInterval.getSeconds()) {
-      LOGGER.debug(
-          "[{}] Device Auth Flow: server requested minimum poll interval of {} seconds",
-          getAgentName(),
-          serverPollInterval);
-      pollInterval = Duration.ofSeconds(serverPollInterval);
-    }
-  }
-
   private void printExpirationNotice(long seconds) {
     String exp;
     if (seconds < 60) {
@@ -171,59 +159,97 @@ abstract class DeviceCodeFlow extends AbstractFlow {
     console.println(getMsgPrefix() + "(The code will expire in " + exp + ")");
   }
 
-  private void pollForNewTokens(DeviceCode deviceCode) {
-    LOGGER.debug("[{}] Device Auth Flow: polling for new tokens", getAgentName());
-    invokeTokenEndpoint(new DeviceCodeGrant(deviceCode))
-        .whenComplete(
-            (tokens, error) -> {
-              if (error == null) {
-                LOGGER.debug("[{}] Device Auth Flow: new tokens received", getAgentName());
-                getTokensFuture().complete(tokens);
-              } else {
-                if (error instanceof CompletionException) {
-                  error = error.getCause();
-                }
-                if (error instanceof OAuth2Exception) {
-                  switch (((OAuth2Exception) error).getErrorObject().getCode()) {
-                    case "authorization_pending":
-                      LOGGER.debug(
-                          "[{}] Device Auth Flow: waiting for authorization to complete",
-                          getAgentName());
-                      pollFuture =
-                          getRuntime()
-                              .getExecutor()
-                              .schedule(
-                                  () -> pollForNewTokens(deviceCode),
-                                  pollInterval.toMillis(),
-                                  TimeUnit.MILLISECONDS);
-                      return;
-                    case "slow_down":
-                      LOGGER.debug(
-                          "[{}] Device Auth Flow: server requested to slow down", getAgentName());
-                      Duration pollInterval = this.pollInterval;
-                      boolean ignoreServerPollInterval =
-                          getConfig().getDeviceCodeConfig().ignoreServerPollInterval();
-                      if (!ignoreServerPollInterval) {
-                        pollInterval = pollInterval.plus(pollInterval);
-                        this.pollInterval = pollInterval;
-                      }
-                      pollFuture =
-                          getRuntime()
-                              .getExecutor()
-                              .schedule(
-                                  () -> pollForNewTokens(deviceCode),
-                                  pollInterval.toMillis(),
-                                  TimeUnit.MILLISECONDS);
-                      return;
-                    case "access_denied":
-                    case "expired_token":
-                    default:
-                      getTokensFuture().completeExceptionally(error);
-                  }
+  /** Encapsulates mutable state and behavior related to token endpoint polling. */
+  class TokenPoller {
+
+    private final ScheduledExecutorService executor = getRuntime().getExecutor();
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+
+    private volatile Duration pollInterval;
+    private volatile Future<?> pollFuture;
+
+    void start(long serverPollInterval, DeviceCode deviceCode) {
+      pollInterval = getConfig().getDeviceCodeConfig().getPollInterval();
+      boolean ignoreServerPollInterval =
+          getConfig().getDeviceCodeConfig().ignoreServerPollInterval();
+      if (!ignoreServerPollInterval && serverPollInterval > pollInterval.getSeconds()) {
+        LOGGER.debug(
+            "[{}] Device Auth Flow: server requested minimum poll interval of {} seconds",
+            getAgentName(),
+            serverPollInterval);
+        pollInterval = Duration.ofSeconds(serverPollInterval);
+      }
+      scheduleNextPoll(deviceCode);
+    }
+
+    void stop() {
+      if (stopped.compareAndSet(false, true)) {
+        LOGGER.debug("[{}] Device Auth Flow: stopping polling", getAgentName());
+        try {
+          Future<?> future = this.pollFuture;
+          if (future != null) {
+            future.cancel(true);
+          }
+        } finally {
+          this.pollFuture = null;
+        }
+      }
+    }
+
+    private void poll(DeviceCode deviceCode) {
+      LOGGER.debug("[{}] Device Auth Flow: polling for new tokens", getAgentName());
+      invokeTokenEndpoint(new DeviceCodeGrant(deviceCode))
+          .whenComplete(
+              (tokens, error) -> {
+                if (error == null) {
+                  LOGGER.debug("[{}] Device Auth Flow: new tokens received", getAgentName());
+                  getTokensFuture().complete(tokens);
                 } else {
-                  getTokensFuture().completeExceptionally(error);
+                  Throwable cause = error;
+                  if (cause instanceof CompletionException) {
+                    cause = error.getCause();
+                  }
+                  if (cause instanceof OAuth2Exception) {
+                    switch (((OAuth2Exception) cause).getErrorObject().getCode()) {
+                      case "authorization_pending":
+                        LOGGER.debug(
+                            "[{}] Device Auth Flow: waiting for authorization to complete",
+                            getAgentName());
+                        scheduleNextPoll(deviceCode);
+                        break;
+                      case "slow_down":
+                        LOGGER.debug(
+                            "[{}] Device Auth Flow: server requested to slow down", getAgentName());
+                        boolean ignoreServerPollInterval =
+                            getConfig().getDeviceCodeConfig().ignoreServerPollInterval();
+                        if (!ignoreServerPollInterval) {
+                          Duration interval = pollInterval;
+                          pollInterval = interval.plus(interval);
+                        }
+                        scheduleNextPoll(deviceCode);
+                        break;
+                      default:
+                        getTokensFuture().completeExceptionally(cause);
+                    }
+                  } else {
+                    getTokensFuture().completeExceptionally(cause);
+                  }
                 }
-              }
-            });
+              });
+    }
+
+    private void scheduleNextPoll(DeviceCode deviceCode) {
+      if (!stopped.get()) {
+        Future<?> future =
+            executor.schedule(
+                () -> poll(deviceCode), pollInterval.toMillis(), TimeUnit.MILLISECONDS);
+        pollFuture = future;
+        if (stopped.get()) {
+          // We raced with stop(): clear the field and cancel the future we just created.
+          pollFuture = null;
+          future.cancel(true);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Encapsulate `DeviceCodeFlow`'s mutable polling state into a `TokenPoller` inner class in order to avoid a race window between scheduling and cancellation.

Also return `getTokensFuture()` directly from `fetchNewTokens()` so that cancelling the result propagates to the underlying future and stops polling.