### PR TITLE
feat(device-code): remove poll-interval configuration option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,10 +294,6 @@ URL of the OAuth2 device authorization endpoint. For Keycloak, this is typically
 
 If using the "Device Code" grant type, either this property or `rest.auth.oauth2.issuer-url` must be set.
 
-### `rest.auth.oauth2.device-code.poll-interval`
-
-Defines how often the agent should poll the OAuth2 server for the device code flow to complete. This is only used if the grant type to use is `urn:ietf:params:oauth:grant-type:device_code`. Optional, defaults to `PT5S`.
-
 ## Token Exchange Settings
 
 Configuration properties for the [Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) flow.

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
@@ -32,6 +32,9 @@ public class ConfigRelocationInterceptor implements ConfigSourceInterceptor {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRelocationInterceptor.class);
   private static final String ROOT_PREFIX = OAuth2Config.PREFIX + '.';
 
+  private static final Set<String> REMOVED_PROPERTIES =
+      Set.of(DeviceCodeConfig.PREFIX + ".poll-interval");
+
   private static final List<RelocationRule> RELOCATION_RULES =
       List.of(
           new RelocationRule(
@@ -57,12 +60,17 @@ public class ConfigRelocationInterceptor implements ConfigSourceInterceptor {
 
   @Override
   public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {
-    // Only include relocated (canonical) names; filter out legacy aliases
+    // Only include relocated (canonical) names; filter out legacy aliases and removed properties
     // to avoid mapping errors "SRCFG00050 ... does not map to any root"
     Set<String> canonicalNames = new LinkedHashSet<>();
     Iterator<String> names = context.iterateNames();
     while (names.hasNext()) {
-      canonicalNames.add(toCanonicalName(names.next()));
+      String canonical = toCanonicalName(names.next());
+      if (REMOVED_PROPERTIES.contains(canonical)) {
+        LOGGER.warn("Property '{}' has been removed and will be ignored", canonical);
+        continue;
+      }
+      canonicalNames.add(canonical);
     }
     return canonicalNames.iterator();
   }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/DeviceCodeConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/DeviceCodeConfig.java
@@ -17,11 +17,8 @@ package com.dremio.iceberg.authmgr.oauth2.config;
 
 import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
 import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
-import com.nimbusds.oauth2.sdk.GrantType;
-import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import java.net.URI;
-import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -38,9 +35,6 @@ public interface DeviceCodeConfig {
   String PREFIX = OAuth2Config.PREFIX + '.' + GROUP_NAME;
 
   String ENDPOINT = "endpoint";
-  String POLL_INTERVAL = "poll-interval";
-
-  String DEFAULT_POLL_INTERVAL = "PT5S";
 
   /**
    * URL of the OAuth2 device authorization endpoint. For Keycloak, this is typically {@code
@@ -52,39 +46,6 @@ public interface DeviceCodeConfig {
   @WithName(ENDPOINT)
   Optional<URI> getDeviceAuthorizationEndpoint();
 
-  /**
-   * Defines how often the agent should poll the OAuth2 server for the device code flow to complete.
-   * This is only used if the grant type to use is {@link GrantType#DEVICE_CODE}. Optional, defaults
-   * to {@value #DEFAULT_POLL_INTERVAL}.
-   */
-  @WithName(POLL_INTERVAL)
-  @WithDefault(DEFAULT_POLL_INTERVAL)
-  Duration getPollInterval();
-
-  /**
-   * The minimum poll interval for the device code flow. The device code flow requires a minimum
-   * poll interval of 5 seconds.
-   *
-   * <p>This setting is not exposed as a configuration option and is intended for testing purposes.
-   *
-   * @hidden
-   */
-  @WithName("min-poll-interval")
-  @WithDefault(DEFAULT_POLL_INTERVAL) // mandated by the specs
-  Duration getMinPollInterval();
-
-  /**
-   * Whether to ignore the server-specified poll interval and always use the configured poll
-   * interval.
-   *
-   * <p>This setting is not exposed as a configuration option and is intended for testing purposes.
-   *
-   * @hidden
-   */
-  @WithName("ignore-server-poll-interval")
-  @WithDefault("false")
-  boolean ignoreServerPollInterval();
-
   default void validate() {
     ConfigValidator validator = new ConfigValidator();
     if (getDeviceAuthorizationEndpoint().isPresent()) {
@@ -93,11 +54,6 @@ public interface DeviceCodeConfig {
           PREFIX + '.' + ENDPOINT,
           "device code flow: device authorization endpoint");
     }
-    validator.check(
-        getPollInterval().compareTo(getMinPollInterval()) >= 0,
-        PREFIX + '.' + POLL_INTERVAL,
-        "device code flow: poll interval must be greater than or equal to %s",
-        getMinPollInterval());
     validator.validate();
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlow.java
@@ -169,16 +169,7 @@ abstract class DeviceCodeFlow extends AbstractFlow {
     private volatile Future<?> pollFuture;
 
     void start(long serverPollInterval, DeviceCode deviceCode) {
-      pollInterval = getConfig().getDeviceCodeConfig().getPollInterval();
-      boolean ignoreServerPollInterval =
-          getConfig().getDeviceCodeConfig().ignoreServerPollInterval();
-      if (!ignoreServerPollInterval && serverPollInterval > pollInterval.getSeconds()) {
-        LOGGER.debug(
-            "[{}] Device Auth Flow: server requested minimum poll interval of {} seconds",
-            getAgentName(),
-            serverPollInterval);
-        pollInterval = Duration.ofSeconds(serverPollInterval);
-      }
+      pollInterval = Duration.ofSeconds(serverPollInterval);
       scheduleNextPoll(deviceCode);
     }
 
@@ -220,12 +211,8 @@ abstract class DeviceCodeFlow extends AbstractFlow {
                       case "slow_down":
                         LOGGER.debug(
                             "[{}] Device Auth Flow: server requested to slow down", getAgentName());
-                        boolean ignoreServerPollInterval =
-                            getConfig().getDeviceCodeConfig().ignoreServerPollInterval();
-                        if (!ignoreServerPollInterval) {
-                          Duration interval = pollInterval;
-                          pollInterval = interval.plus(interval);
-                        }
+                        Duration interval = pollInterval;
+                        pollInterval = interval.plus(interval);
                         scheduleNextPoll(deviceCode);
                         break;
                       default:

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ConfigTest.java
@@ -177,6 +177,18 @@ class OAuth2ConfigTest {
             PREFIX + ".unknown in catalog session properties does not map to any root");
   }
 
+  @Test
+  void testFromRemovedProperties() {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT, "https://example.com/token")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_ID, "my-client")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "s3cr3t")
+            .put(PREFIX + ".device-code.poll-interval", "PT10S")
+            .build();
+    assertThat(OAuth2Config.from(properties)).isNotNull();
+  }
+
   @ParameterizedTest
   @MethodSource
   void testValidate(Map<String, String> properties, List<String> expected) {

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
@@ -144,6 +144,27 @@ class ConfigRelocationInterceptorTest {
   }
 
   @Test
+  void testIterateNamesFiltersRemovedProperties() {
+    SmallRyeConfig config =
+        new SmallRyeConfigBuilder()
+            .setAddDefaultSources(false)
+            .setAddDiscoveredSources(false)
+            .setAddDiscoveredConverters(false)
+            .setAddDiscoveredInterceptors(false)
+            .setAddDiscoveredSecretKeysHandlers(false)
+            .setAddDiscoveredValidator(false)
+            .withInterceptors(new ConfigRelocationInterceptor())
+            .withSources(
+                new MapBackedConfigSource(
+                    "catalog-properties",
+                    Map.of("rest.auth.oauth2.device-code.poll-interval", "PT5S"),
+                    1000) {})
+            .build();
+    assertThat(StreamSupport.stream(config.getPropertyNames().spliterator(), false).toList())
+        .isEmpty();
+  }
+
+  @Test
   void testCanonicalLookupsResolveLegacyAliases() {
     SmallRyeConfig config =
         new SmallRyeConfigBuilder()

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/DeviceCodeConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/DeviceCodeConfigTest.java
@@ -16,7 +16,6 @@
 package com.dremio.iceberg.authmgr.oauth2.config;
 
 import static com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig.ENDPOINT;
-import static com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig.POLL_INTERVAL;
 import static com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig.PREFIX;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -61,14 +60,6 @@ class DeviceCodeConfigTest {
         Arguments.of(
             Map.of(PREFIX + '.' + ENDPOINT, "https://example.com#fragment"),
             singletonList(
-                "device code flow: device authorization endpoint must not have a fragment part (rest.auth.oauth2.device-code.endpoint)")),
-        Arguments.of(
-            Map.of(
-                PREFIX + '.' + ENDPOINT,
-                "https://example.com",
-                PREFIX + '.' + POLL_INTERVAL,
-                "PT1S"),
-            singletonList(
-                "device code flow: poll interval must be greater than or equal to PT5S (rest.auth.oauth2.device-code.poll-interval)")));
+                "device code flow: device authorization endpoint must not have a fragment part (rest.auth.oauth2.device-code.endpoint)")));
   }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -452,12 +452,6 @@ public abstract class TestEnvironment implements AutoCloseable {
   @Value.Default
   public Map<String, String> getDeviceCodeConfig() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    builder
-        .put(DeviceCodeConfig.PREFIX + '.' + DeviceCodeConfig.POLL_INTERVAL, "PT0.01S")
-        .put(DeviceCodeConfig.PREFIX + '.' + "min-poll-interval", "PT0.01S")
-        .put(
-            DeviceCodeConfig.PREFIX + '.' + "ignore-server-poll-interval",
-            isUnitTest() ? "true" : "false");
     if (!isDiscoveryEnabled()) {
       builder.put(
           DeviceCodeConfig.PREFIX + '.' + DeviceCodeConfig.ENDPOINT,

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/DeviceCodeExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/DeviceCodeExpectation.java
@@ -112,8 +112,9 @@ public abstract class DeviceCodeExpectation extends InitialTokenFetchExpectation
                               getTestEnvironment().getDeviceVerificationEndpoint().toString(),
                               "expires_in",
                               300,
+                              // Zero is not a valid interval per the RFC, but speeds up unit tests
                               "interval",
-                              1)));
+                              0)));
             });
   }
 


### PR DESCRIPTION
Summary of changes:

Removed `rest.auth.oauth2.device-code.poll-interval`. The poll interval now always respects the server-provided value, and `slow_down` responses always double the interval, aligning with RFC 8628.

Removed the testing-only `minPollInterval` and `ignoreServerPollInterval` config options from `DeviceCodeConfig`. These were a bit overkill for little added value. Instead, the `DeviceCodeExpectation` now replies with `interval: 0`, thus achieving the same result (speed up unit tests).