### PR TITLE
fix(flow): return failed future instead of throwing synchronously

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
@@ -105,8 +105,13 @@ abstract class AbstractFlow implements Flow {
   abstract EndpointProvider getEndpointProvider();
 
   CompletionStage<TokensResult> invokeTokenEndpoint(AuthorizationGrant grant) {
-    TokenRequest.Builder builder = newTokenRequestBuilder(grant);
-    HTTPRequest request = builder.build().toHTTPRequest();
+    HTTPRequest request;
+    try {
+      TokenRequest.Builder builder = newTokenRequestBuilder(grant);
+      request = builder.build().toHTTPRequest();
+    } catch (Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
     return CompletableFuture.supplyAsync(() -> sendAndReceive(request), getRuntime().getExecutor())
         .whenComplete((response, error) -> log(request, response, error))
         .thenApply(this::parseTokenResponse)


### PR DESCRIPTION
Wrap request construction in try/catch so that exceptions from `newTokenRequestBuilder` or `toHTTPRequest` are returned as a failed `CompletableFuture` rather than propagating synchronously. Callers expect errors through the `CompletionStage` error channel.