### PR TITLE
feat(config): validate subject token is set

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
@@ -157,6 +157,15 @@ public interface OAuth2Config {
           "either issuer URL or device authorization endpoint must be set if grant type is '%s'",
           GrantType.DEVICE_CODE.getValue());
     }
+    if (grantType.equals(GrantType.TOKEN_EXCHANGE)) {
+      validator.check(
+          getTokenExchangeConfig().getSubjectToken().isPresent()
+              || getTokenExchangeConfig().getSubjectTokenFile().isPresent()
+              || !getTokenExchangeConfig().getSubjectTokenConfig().isEmpty(),
+          TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.SUBJECT_TOKEN,
+          "subject token must be set if grant type is '%s'",
+          GrantType.TOKEN_EXCHANGE.getValue());
+    }
     ClientAuthenticationMethod method = getBasicConfig().getClientAuthenticationMethod();
     if (ConfigUtils.requiresJwsAlgorithm(method)) {
       if (method.equals(ClientAuthenticationMethod.CLIENT_SECRET_JWT)) {

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/SubjectTokenSupplierTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/SubjectTokenSupplierTest.java
@@ -29,6 +29,9 @@ import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.TokenTypeURI;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -78,7 +81,7 @@ class SubjectTokenSupplierTest {
   @Test
   @SuppressWarnings("resource")
   void testValidate() {
-    OAuth2Config config = createMainConfig(null, null, TokenTypeURI.ACCESS_TOKEN, Map.of());
+    OAuth2Config config = createInvalidMainConfig();
     assertThatIllegalArgumentException()
         .isThrownBy(() -> createSupplier(config))
         .withMessage("Subject token is dynamic but no configuration is provided");
@@ -102,7 +105,28 @@ class SubjectTokenSupplierTest {
       Path subjectTokenFile,
       TokenTypeURI subjectTokenType,
       Map<String, String> subjectTokenConfig) {
+    return OAuth2Config.from(
+        createProperties(subjectToken, subjectTokenFile, subjectTokenType, subjectTokenConfig));
+  }
 
+  private static OAuth2Config createInvalidMainConfig() {
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withSources(
+                new MapBackedConfigSource(
+                    "catalog properties",
+                    createProperties(null, null, TokenTypeURI.ACCESS_TOKEN, Map.of()),
+                    200) {})
+            .withMapping(OAuth2Config.class)
+            .build();
+    return smallRyeConfig.getConfigMapping(OAuth2Config.class);
+  }
+
+  private static Map<String, String> createProperties(
+      String subjectToken,
+      Path subjectTokenFile,
+      TokenTypeURI subjectTokenType,
+      Map<String, String> subjectTokenConfig) {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
     builder.put(PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.TOKEN_EXCHANGE.getValue());
@@ -129,7 +153,7 @@ class SubjectTokenSupplierTest {
           subjectTokenFile.toString());
     }
 
-    return OAuth2Config.from(builder.build());
+    return builder.build();
   }
 
   private static SubjectTokenSupplier createSupplier(OAuth2Config config) {


### PR DESCRIPTION
Add a cross-config validation in `OAuth2Config` that requires at least one subject token source (inline token, token file, or dynamic config) when the grant type is `TOKEN_EXCHANGE`. This catches misconfiguration early with a clear error message.