### PR TITLE
fix(auth-code): use HTTP 200 for failure response page

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AuthorizationCodeFlow.java
@@ -16,7 +16,6 @@
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
@@ -261,7 +260,7 @@ abstract class AuthorizationCodeFlow extends AbstractFlow {
       if (error == null) {
         writeResponse(exchange, HTTP_OK, HTML_TEMPLATE_OK);
       } else {
-        writeResponse(exchange, HTTP_UNAUTHORIZED, HTML_TEMPLATE_FAILED, error.toString());
+        writeResponse(exchange, HTTP_OK, HTML_TEMPLATE_FAILED, error.toString());
       }
     } catch (IOException e) {
       LOGGER.debug("[{}] Authorization Code Flow: error writing response", getAgentName(), e);


### PR DESCRIPTION
Change the authorization code callback failure response from HTTP 401 to HTTP 200. The response is an HTML page intended for browser display; a 401 status can cause some browsers to show their own error page instead of the styled error content.