### PR TITLE
feat(token-exchange): rename resource/audience to resources/audiences

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,13 +381,15 @@ rest.auth.oauth2.token-exchange.actor-token.client-secret=actor-client-secret
 
 The above configuration will result in a token exchange where the actor token is obtained using the client credentials grant type, with specific client ID and secret, but sharing the token endpoint, client authentication method and other settings with the main agent.
 
-### `rest.auth.oauth2.token-exchange.resource`
+### `rest.auth.oauth2.token-exchange.resources`
 
-A URI that indicates the target service or resource where the client intends to use the requested security token. Optional.
+One or more URIs that indicate the target service(s) or resource(s) where the client intends to use the requested security token.
 
-### `rest.auth.oauth2.token-exchange.audience`
+Optional. Can be a single value or a comma-separated list of values.
 
-The logical name of the target service where the client intends to use the requested security token. This serves a purpose similar to the resource parameter but with the client providing a logical name for the target service.
+### `rest.auth.oauth2.token-exchange.audiences`
+
+The logical name of the target service(s) where the client intends to use the requested security token. This serves a purpose similar to the resource parameter but with the client providing a logical name for the target service.
 
 Optional. Can be a single value or a comma-separated list of values.
 

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
@@ -38,7 +38,17 @@ public class ConfigRelocationInterceptor implements ConfigSourceInterceptor {
               Pattern.compile("\\.callback-"),
               ".callback.",
               Pattern.compile("\\.callback\\."),
-              ".callback-"));
+              ".callback-"),
+          new RelocationRule(
+              Pattern.compile("\\.token-exchange\\.resource$"),
+              ".token-exchange.resources",
+              Pattern.compile("\\.token-exchange\\.resources$"),
+              ".token-exchange.resource"),
+          new RelocationRule(
+              Pattern.compile("\\.token-exchange\\.audience$"),
+              ".token-exchange.audiences",
+              Pattern.compile("\\.token-exchange\\.audiences$"),
+              ".token-exchange.audience"));
 
   @Override
   public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/TokenExchangeConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/TokenExchangeConfig.java
@@ -50,8 +50,8 @@ public interface TokenExchangeConfig {
   String ACTOR_TOKEN_FILE = "actor-token-file";
   String ACTOR_TOKEN_TYPE = "actor-token-type";
   String REQUESTED_TOKEN_TYPE = "requested-token-type";
-  String RESOURCE = "resource";
-  String AUDIENCE = "audience";
+  String RESOURCES = "resources";
+  String AUDIENCES = "audiences";
 
   String DEFAULT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
@@ -181,21 +181,23 @@ public interface TokenExchangeConfig {
   Map<String, String> getActorTokenConfig();
 
   /**
-   * A URI that indicates the target service or resource where the client intends to use the
-   * requested security token. Optional.
-   */
-  @WithName(RESOURCE)
-  Optional<URI> getResource();
-
-  /**
-   * The logical name of the target service where the client intends to use the requested security
-   * token. This serves a purpose similar to the resource parameter but with the client providing a
-   * logical name for the target service.
+   * One or more URIs that indicate the target service(s) or resource(s) where the client intends to
+   * use the requested security token.
    *
    * <p>Optional. Can be a single value or a comma-separated list of values.
    */
-  @WithName(AUDIENCE)
-  Optional<List<Audience>> getAudience();
+  @WithName(RESOURCES)
+  Optional<List<URI>> getResources();
+
+  /**
+   * The logical name of the target service(s) where the client intends to use the requested
+   * security token. This serves a purpose similar to the resource parameter but with the client
+   * providing a logical name for the target service.
+   *
+   * <p>Optional. Can be a single value or a comma-separated list of values.
+   */
+  @WithName(AUDIENCES)
+  Optional<List<Audience>> getAudiences();
 
   default void validate() {
     ConfigValidator validator = new ConfigValidator();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlow.java
@@ -24,6 +24,7 @@ import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.TokenTypeURI;
 import com.nimbusds.oauth2.sdk.tokenexchange.TokenExchangeGrant;
+import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -70,7 +71,9 @@ abstract class TokenExchangeFlow extends AbstractFlow {
   TokenRequest.Builder newTokenRequestBuilder(AuthorizationGrant grant) {
     TokenRequest.Builder builder = super.newTokenRequestBuilder(grant);
     TokenExchangeConfig tokenExchangeConfig = getConfig().getTokenExchangeConfig();
-    tokenExchangeConfig.getResource().ifPresent(builder::resources);
+    tokenExchangeConfig
+        .getResources()
+        .ifPresent(list -> builder.resources(list.toArray(URI[]::new)));
     return builder;
   }
 
@@ -88,6 +91,6 @@ abstract class TokenExchangeFlow extends AbstractFlow {
                 ? TokenTypeURI.ACCESS_TOKEN
                 : actorToken.getIssuedTokenType(),
         tokenExchangeConfig.getRequestedTokenType(),
-        tokenExchangeConfig.getAudience().orElseGet(List::of));
+        tokenExchangeConfig.getAudiences().orElseGet(List::of));
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
@@ -47,6 +47,18 @@ class ConfigRelocationInterceptorTest {
         Arguments.of(
             "rest.auth.oauth2.auth-code.callback-bind-host",
             "rest.auth.oauth2.auth-code.callback.bind-host"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.resource",
+            "rest.auth.oauth2.token-exchange.resources"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.audience",
+            "rest.auth.oauth2.token-exchange.audiences"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.resources",
+            "rest.auth.oauth2.token-exchange.resources"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.audiences",
+            "rest.auth.oauth2.token-exchange.audiences"),
         Arguments.of("some.other.property", "some.other.property"));
   }
 
@@ -67,6 +79,16 @@ class ConfigRelocationInterceptorTest {
         Arguments.of(
             "rest.auth.oauth2.auth-code.callback.bind-host",
             "rest.auth.oauth2.auth-code.callback-bind-host"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.resources",
+            "rest.auth.oauth2.token-exchange.resource"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.audiences",
+            "rest.auth.oauth2.token-exchange.audience"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.resource", "rest.auth.oauth2.token-exchange.resource"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.audience", "rest.auth.oauth2.token-exchange.audience"),
         Arguments.of("some.other.property", "some.other.property"));
   }
 
@@ -87,14 +109,18 @@ class ConfigRelocationInterceptorTest {
                     Map.of(
                         "rest.auth.oauth2.auth-code.callback-https", "true",
                         "rest.auth.oauth2.auth-code.callback-bind-port", "8080",
-                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost"),
+                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost",
+                        "rest.auth.oauth2.token-exchange.resource", "urn:resource",
+                        "rest.auth.oauth2.token-exchange.audience", "urn:audience"),
                     1000) {})
             .build();
     assertThat(StreamSupport.stream(config.getPropertyNames().spliterator(), false).toList())
         .containsExactlyInAnyOrder(
             "rest.auth.oauth2.auth-code.callback.https",
             "rest.auth.oauth2.auth-code.callback.bind-port",
-            "rest.auth.oauth2.auth-code.callback.bind-host");
+            "rest.auth.oauth2.auth-code.callback.bind-host",
+            "rest.auth.oauth2.token-exchange.resources",
+            "rest.auth.oauth2.token-exchange.audiences");
   }
 
   @Test
@@ -114,7 +140,9 @@ class ConfigRelocationInterceptorTest {
                     Map.of(
                         "rest.auth.oauth2.auth-code.callback-https", "true",
                         "rest.auth.oauth2.auth-code.callback-bind-port", "8080",
-                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost"),
+                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost",
+                        "rest.auth.oauth2.token-exchange.resource", "urn:resource",
+                        "rest.auth.oauth2.token-exchange.audience", "urn:audience"),
                     1000) {})
             .build();
     assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.https")).isEqualTo("true");
@@ -122,5 +150,9 @@ class ConfigRelocationInterceptorTest {
         .isEqualTo("8080");
     assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.bind-host"))
         .isEqualTo("localhost");
+    assertThat(config.getRawValue("rest.auth.oauth2.token-exchange.resources"))
+        .isEqualTo("urn:resource");
+    assertThat(config.getRawValue("rest.auth.oauth2.token-exchange.audiences"))
+        .isEqualTo("urn:audience");
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/TokenExchangeConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/TokenExchangeConfigTest.java
@@ -16,8 +16,9 @@
 package com.dremio.iceberg.authmgr.oauth2.config;
 
 import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.ACTOR_TOKEN_FILE;
-import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.AUDIENCE;
+import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.AUDIENCES;
 import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.PREFIX;
+import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.RESOURCES;
 import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.SUBJECT_TOKEN;
 import static com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig.SUBJECT_TOKEN_FILE;
 import static java.util.Collections.singletonList;
@@ -30,6 +31,7 @@ import com.nimbusds.oauth2.sdk.id.Audience;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.common.MapBackedConfigSource;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -86,7 +88,7 @@ class TokenExchangeConfigTest {
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
     TokenExchangeConfig config = smallRyeConfig.getConfigMapping(TokenExchangeConfig.class, PREFIX);
-    assertThat(config.getAudience()).isEmpty();
+    assertThat(config.getAudiences()).isEmpty();
   }
 
   @Test
@@ -94,7 +96,7 @@ class TokenExchangeConfigTest {
     Map<String, String> properties =
         ImmutableMap.<String, String>builder()
             .put(PREFIX + '.' + SUBJECT_TOKEN, "subject-token")
-            .put(PREFIX + '.' + AUDIENCE, "https://example.com/resource")
+            .put(PREFIX + '.' + AUDIENCES, "https://example.com/resource")
             .build();
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
@@ -102,17 +104,48 @@ class TokenExchangeConfigTest {
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
     TokenExchangeConfig config = smallRyeConfig.getConfigMapping(TokenExchangeConfig.class, PREFIX);
-    assertThat(config.getAudience())
+    assertThat(config.getAudiences())
         .contains(List.of(new Audience("https://example.com/resource")));
   }
 
   @Test
-  void testMultipleAudiences() {
+  void testResourcesEmpty() {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(PREFIX + '.' + SUBJECT_TOKEN, "subject-token")
+            .build();
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withMapping(TokenExchangeConfig.class, PREFIX)
+            .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
+            .build();
+    TokenExchangeConfig config = smallRyeConfig.getConfigMapping(TokenExchangeConfig.class, PREFIX);
+    assertThat(config.getResources()).isEmpty();
+  }
+
+  @Test
+  void testSingleResource() {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(PREFIX + '.' + SUBJECT_TOKEN, "subject-token")
+            .put(PREFIX + '.' + RESOURCES, "https://example.com/resource")
+            .build();
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withMapping(TokenExchangeConfig.class, PREFIX)
+            .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
+            .build();
+    TokenExchangeConfig config = smallRyeConfig.getConfigMapping(TokenExchangeConfig.class, PREFIX);
+    assertThat(config.getResources()).contains(List.of(URI.create("https://example.com/resource")));
+  }
+
+  @Test
+  void testMultipleResources() {
     Map<String, String> properties =
         ImmutableMap.<String, String>builder()
             .put(PREFIX + '.' + SUBJECT_TOKEN, "subject-token")
             .put(
-                PREFIX + '.' + AUDIENCE,
+                PREFIX + '.' + RESOURCES,
                 "https://example.com/resource1,https://example.com/resource2")
             .build();
     SmallRyeConfig smallRyeConfig =
@@ -121,7 +154,29 @@ class TokenExchangeConfigTest {
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
     TokenExchangeConfig config = smallRyeConfig.getConfigMapping(TokenExchangeConfig.class, PREFIX);
-    assertThat(config.getAudience())
+    assertThat(config.getResources())
+        .contains(
+            List.of(
+                URI.create("https://example.com/resource1"),
+                URI.create("https://example.com/resource2")));
+  }
+
+  @Test
+  void testMultipleAudiences() {
+    Map<String, String> properties =
+        ImmutableMap.<String, String>builder()
+            .put(PREFIX + '.' + SUBJECT_TOKEN, "subject-token")
+            .put(
+                PREFIX + '.' + AUDIENCES,
+                "https://example.com/resource1,https://example.com/resource2")
+            .build();
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withMapping(TokenExchangeConfig.class, PREFIX)
+            .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
+            .build();
+    TokenExchangeConfig config = smallRyeConfig.getConfigMapping(TokenExchangeConfig.class, PREFIX);
+    assertThat(config.getAudiences())
         .contains(
             List.of(
                 new Audience("https://example.com/resource1"),

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -500,12 +500,12 @@ public abstract class TestEnvironment implements AutoCloseable {
     }
     if (getAudience() != null) {
       builder.put(
-          TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.AUDIENCE,
+          TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.AUDIENCES,
           getAudience().toString());
     }
     if (getResource() != null) {
       builder.put(
-          TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.RESOURCE,
+          TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.RESOURCES,
           getResource().toString());
     }
     return builder.build();


### PR DESCRIPTION
Rename config options to plural form to reflect that they accept multiple values. Add config relocations for backward compatibility with the old singular property names. Add tests for resources parsing.

Not ready yet. Requires #210.