### PR TITLE
fix(config): set default access token lifespan to 1 hour

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ Whether to enable token refresh. If enabled, the agent will automatically refres
 
 Default access token lifespan; if the OAuth2 server returns an access token without specifying its expiration time, this value will be used. Note that when this happens, a warning will be logged.
 
-Optional, defaults to `PT5M`. Must be a valid [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+Optional, defaults to `PT1H`. Must be a valid [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 
 ### `rest.auth.oauth2.token-refresh.safety-window`
 

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/TokenRefreshConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/TokenRefreshConfig.java
@@ -34,7 +34,7 @@ public interface TokenRefreshConfig {
   String SAFETY_WINDOW = "safety-window";
   String IDLE_TIMEOUT = "idle-timeout";
 
-  String DEFAULT_ACCESS_TOKEN_LIFESPAN = "PT5M";
+  String DEFAULT_ACCESS_TOKEN_LIFESPAN = "PT1H";
   String DEFAULT_SAFETY_WINDOW = "PT10S";
   String DEFAULT_IDLE_TIMEOUT = "PT30S";
 


### PR DESCRIPTION
Change the default access token lifespan fallback from 5 minutes to 1 hour. 5 minutes is unrealistic and may trigger token renewals too frequently.