### PR TITLE
feat(jwt-bearer): Add support for JWT Bearer grants

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,11 +52,33 @@ The Dremio AuthManager for Apache Iceberg supports several client authentication
 [Client Authentication](./client-authentication.md) section for more details on how to configure
 client authentication.
 
-## Impersonation & Delegation
+## Grant Types
+
+The Dremio AuthManager for Apache Iceberg supports several OAuth2 grant types:
+
+* Client Credentials Grant ([RFC 6749, Section 4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4))
+* Authorization Code Grant ([RFC 6749, Section 4.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1))
+* Device Authorization Grant ([RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628))
+* [Token Exchange Grant](./token-exchange.md) ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693))
+* [JWT Bearer Grant](./jwt-bearer.md) ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523))
+
+The Dremio AuthManager also supports the Resource Owner Password Credentials Grant 
+([RFC 6749, Section 4.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3)), but this grant 
+type is deprecated and should be avoided if possible.
+
+See the [Configuration](./configuration.md) section for more details on how to configure grant 
+types.
+
+### Impersonation & Delegation
 
 The Dremio AuthManager for Apache Iceberg supports impersonation and delegation using the token
 exchange grant type. See the [Token Exchange](./token-exchange.md) section for more details on how
 to configure impersonation and delegation.
+
+### Assertion Grants
+
+The Dremio AuthManager for Apache Iceberg supports JWT assertion grants with static or dynamic
+assertions. See the [JWT Bearer Grant](./jwt-bearer.md) section for more details.
 
 ## Migration From Iceberg's Built-In OAuth2 `AuthManager`
 

--- a/docs/client-authentication.md
+++ b/docs/client-authentication.md
@@ -89,7 +89,7 @@ Example configuration:
 rest.auth.oauth2.client-auth=client_secret_jwt
 rest.auth.oauth2.client-id=my-client
 rest.auth.oauth2.client-secret=my-secret
-rest.auth.oauth2.client-assertion.jwt.algorithm=HMAC_SHA256
+rest.auth.oauth2.client-auth.jwt.algorithm=HMAC_SHA256
 ```
 
 #### `private_key_jwt`
@@ -101,11 +101,11 @@ Example configuration:
 ```properties
 rest.auth.oauth2.client-auth=private_key_jwt
 rest.auth.oauth2.client-id=my-client
-rest.auth.oauth2.client-assertion.jwt.algorithm=RSA_SHA256
-rest.auth.oauth2.client-assertion.jwt.private-key=/path/to/private_key.pem
+rest.auth.oauth2.client-auth.jwt.algorithm=RSA_SHA256
+rest.auth.oauth2.client-auth.jwt.private-key=/path/to/private_key.pem
 ```
 
-When using this method, the private key file must be provided using the `rest.auth.oauth2.client-assertion.jwt.private-key` property. 
+When using this method, the private key file must be provided using the `rest.auth.oauth2.client-auth.jwt.private-key` property. 
 
 The file must be in PEM format. It may contain multiple objects; the first private key encountered
 in the file is used.
@@ -134,16 +134,16 @@ The JWT assertion includes the following claims:
 Each of these claims (except `iat`) can be customized using the following configuration properties:
 
 ```properties
-rest.auth.oauth2.client-assertion.jwt.issuer=my-issuer
-rest.auth.oauth2.client-assertion.jwt.subject=my-subject
-rest.auth.oauth2.client-assertion.jwt.audience=https://example.com/token
-rest.auth.oauth2.client-assertion.jwt.token-lifespan=PT10M
+rest.auth.oauth2.client-auth.jwt.issuer=my-issuer
+rest.auth.oauth2.client-auth.jwt.subject=my-subject
+rest.auth.oauth2.client-auth.jwt.audience=https://example.com/token
+rest.auth.oauth2.client-auth.jwt.token-lifespan=PT10M
 ```
 
-The signing algorithm can be specified using the `rest.auth.oauth2.client-assertion.jwt.algorithm` property. The default is `HMAC_SHA512` for `client_secret_jwt` and `RSA_SHA512` for `private_key_jwt` (algorithm names are case-insensitive). Example:
+The signing algorithm can be specified using the `rest.auth.oauth2.client-auth.jwt.algorithm` property. The default is `HMAC_SHA512` for `client_secret_jwt` and `RSA_SHA512` for `private_key_jwt` (algorithm names are case-insensitive). Example:
 
 ```properties
-rest.auth.oauth2.client-assertion.jwt.algorithm=HMAC_SHA384
+rest.auth.oauth2.client-auth.jwt.algorithm=HMAC_SHA384
 ```
 
 Supported algorithms are:
@@ -165,8 +165,8 @@ For `private_key_jwt`:
 | `RSA_SHA512` | `RS512`, `SHA512withRSA`   |
 
 
-And finally, extra claims can be added to the JWT assertion using the `rest.auth.oauth2.client-assertion.jwt.extra-claims.*` prefix property. Example:
+And finally, extra claims can be added to the JWT assertion using the `rest.auth.oauth2.client-auth.jwt.extra-claims.*` prefix property. Example:
 
 ```properties
-rest.auth.oauth2.client-assertion.jwt.extra-claims.my-claim=my-value
+rest.auth.oauth2.client-auth.jwt.extra-claims.my-claim=my-value
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,7 @@ The grant type to use when authenticating against the OAuth2 server. Valid value
 - `authorization_code`
 - `urn:ietf:params:oauth:grant-type:device_code`
 - `urn:ietf:params:oauth:grant-type:token-exchange`
+- `urn:ietf:params:oauth:grant-type:jwt-bearer`
 
 Optional, defaults to `client_credentials`.
 
@@ -393,35 +394,57 @@ The logical name of the target service(s) where the client intends to use the re
 
 Optional. Can be a single value or a comma-separated list of values.
 
-## Client Assertion Settings
+## Jwt Bearer Settings
+
+Configuration properties for the JWT bearer grant as specified in [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523).
+
+The assertion can be supplied statically or fetched dynamically using a nested OAuth2 configuration.
+
+### `rest.auth.oauth2.jwt-bearer.assertion`
+
+The assertion to exchange.
+
+If this value is present, the assertion is used as-is. If this value is not present, the assertion may be read from the file specified by `rest.auth.oauth2.jwt-bearer.assertion-file`, or dynamically fetched using the configuration provided under the `rest.auth.oauth2.jwt-bearer.assertion` prefix.
+
+### `rest.auth.oauth2.jwt-bearer.assertion-file`
+
+Path to a file containing the assertion. The file content is read and trimmed to obtain the assertion value. Ignored if `rest.auth.oauth2.jwt-bearer.assertion` is set.
+
+### `rest.auth.oauth2.jwt-bearer.assertion.*`
+
+The configuration to use for fetching the assertion dynamically.
+
+This is a prefix property; any property that can be set under the `rest.auth.oauth2.` prefix can also be set under this prefix.
+
+## Jwt Client Auth Settings
 
 Configuration properties for JWT client assertion as specified in [JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7523).
 
 These properties allow the client to authenticate using the `client_secret_jwt` or `private_key_jwt` authentication methods.
 
-### `rest.auth.oauth2.client-assertion.jwt.issuer`
+### `rest.auth.oauth2.client-auth.jwt.issuer`
 
 The issuer of the client assertion JWT. Optional. The default is the client ID.
 
-### `rest.auth.oauth2.client-assertion.jwt.subject`
+### `rest.auth.oauth2.client-auth.jwt.subject`
 
 The subject of the client assertion JWT. Optional. The default is the client ID.
 
-### `rest.auth.oauth2.client-assertion.jwt.audience`
+### `rest.auth.oauth2.client-auth.jwt.audience`
 
 The audience of the client assertion JWT. Optional. The default is the token endpoint. Can be a single audience or a comma-separated list of audiences.
 
-### `rest.auth.oauth2.client-assertion.jwt.token-lifespan`
+### `rest.auth.oauth2.client-auth.jwt.token-lifespan`
 
 The expiration time of the client assertion JWT. Optional. The default is 5 minutes.
 
-### `rest.auth.oauth2.client-assertion.jwt.algorithm`
+### `rest.auth.oauth2.client-auth.jwt.algorithm`
 
 The signing algorithm to use for the client assertion JWT. Optional. The default is `HS512` if the authentication method is `client_secret_jwt`, or `RS512` if the authentication method is `private_key_jwt`.
 
 Algorithm names must match the "alg" Param Value as described in [RFC 7518 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).
 
-### `rest.auth.oauth2.client-assertion.jwt.key-id`
+### `rest.auth.oauth2.client-auth.jwt.key-id`
 
 The key ID (kid) to include in the JWT header. Optional.
 
@@ -429,7 +452,7 @@ If specified, this will be included in the "kid" header parameter of the JWT ass
 
 This setting is only supported when using the `private_key_jwt` authentication method. It is ignored when using `client_secret_jwt`.
 
-### `rest.auth.oauth2.client-assertion.jwt.private-key`
+### `rest.auth.oauth2.client-auth.jwt.private-key`
 
 The path on the local filesystem to the private key to use for signing the client assertion JWT. Required if the authentication method is `private_key_jwt`.
 
@@ -443,7 +466,7 @@ Supported key formats are:
 
 Only unencrypted keys are supported currently.
 
-### `rest.auth.oauth2.client-assertion.jwt.extra-claims.*`
+### `rest.auth.oauth2.client-auth.jwt.extra-claims.*`
 
 Extra claims to include in the client assertion JWT. This is a prefix property, and multiple values can be set, each with a different key and value.
 

--- a/docs/jwt-bearer.md
+++ b/docs/jwt-bearer.md
@@ -42,13 +42,13 @@ Here is an example of using a static assertion:
 ```properties
 rest.auth.type=com.dremio.iceberg.authmgr.oauth2.OAuth2Manager
 
-rest.auth.oauth2.issuer-url=https://$IDP/realms/main
+rest.auth.oauth2.issuer-url=https://idp.example.com/realms/main
 rest.auth.oauth2.grant-type=urn:ietf:params:oauth:grant-type:jwt-bearer
-rest.auth.oauth2.client-id=Client1
-rest.auth.oauth2.client-secret=$CLIENT1_SECRET
-rest.auth.oauth2.scope=catalog1
+rest.auth.oauth2.client-id=my-client
+rest.auth.oauth2.client-secret=s3cret
+rest.auth.oauth2.scope=catalog
 
-rest.auth.oauth2.jwt-bearer.assertion=$ASSERTION
+rest.auth.oauth2.jwt-bearer.assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature
 ```
 
 ### Using Dynamic Assertions

--- a/docs/jwt-bearer.md
+++ b/docs/jwt-bearer.md
@@ -1,0 +1,87 @@
+<!--
+Copyright (C) 2025 Dremio Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Dremio AuthManager for Apache Iceberg - JWT Bearer Grant
+
+## Overview
+
+The Dremio AuthManager for Apache Iceberg supports the
+[JWT Bearer Grant](https://datatracker.ietf.org/doc/html/rfc7523).
+
+Assertions can be provided in two methods:
+
+* Static assertions: assertions acquired externally and directly included in the configuration.
+* Dynamic assertions: assertions are fetched dynamically by the AuthManager, using the same or
+  different credentials and possibly a different IDP.
+
+### Using Static Assertions
+
+Static assertions are provided using the following properties:
+
+* `rest.auth.oauth2.jwt-bearer.assertion`: the inline assertion value.
+* `rest.auth.oauth2.jwt-bearer.assertion-file`: path to a file whose content (read and
+  trimmed) is used as the assertion; ignored if `assertion` is set.
+
+The assertion is taken from the inline `assertion` if set, otherwise from the file at
+`assertion-file` if set, otherwise from dynamic configuration under `assertion.*`.
+
+Here is an example of using a static assertion:
+
+```properties
+rest.auth.type=com.dremio.iceberg.authmgr.oauth2.OAuth2Manager
+
+rest.auth.oauth2.issuer-url=https://$IDP/realms/main
+rest.auth.oauth2.grant-type=urn:ietf:params:oauth:grant-type:jwt-bearer
+rest.auth.oauth2.client-id=Client1
+rest.auth.oauth2.client-secret=$CLIENT1_SECRET
+rest.auth.oauth2.scope=catalog1
+
+rest.auth.oauth2.jwt-bearer.assertion=$ASSERTION
+```
+
+### Using Dynamic Assertions
+
+To enable dynamic fetching of assertions, the `rest.auth.oauth2.jwt-bearer.assertion` and
+`rest.auth.oauth2.jwt-bearer.assertion-file` properties must _not_ be set.
+
+Then, details for fetching the assertion must be provided under:
+
+* `rest.auth.oauth2.jwt-bearer.assertion.*`
+
+Any property that can be set under the `rest.auth.oauth2.` prefix can also be set under this
+prefix, and will be used to configure a secondary agent for fetching the assertion.
+
+```properties
+rest.auth.type=com.dremio.iceberg.authmgr.oauth2.OAuth2Manager
+
+rest.auth.oauth2.issuer-url=https://$PRIMARY_IDP/realms/primary
+rest.auth.oauth2.grant-type=urn:ietf:params:oauth:grant-type:jwt-bearer
+rest.auth.oauth2.client-id=Client1
+rest.auth.oauth2.client-secret=$CLIENT1_SECRET
+rest.auth.oauth2.scope=catalog1
+
+rest.auth.oauth2.jwt-bearer.assertion.issuer-url=https://$SECONDARY_IDP/realms/secondary
+rest.auth.oauth2.jwt-bearer.assertion.grant-type=authorization_code
+rest.auth.oauth2.jwt-bearer.assertion.client-id=Client2
+rest.auth.oauth2.jwt-bearer.assertion.client-secret=$CLIENT2_SECRET
+rest.auth.oauth2.jwt-bearer.assertion.scope=catalog2
+```
+
+For Microsoft Entra ID on-behalf-of requests, configure the assertion using one of the above
+methods and add vendor-specific parameters with `rest.auth.oauth2.extra-params.*`, for example:
+
+```properties
+rest.auth.oauth2.extra-params.requested_token_use=on_behalf_of
+```

--- a/docs/token-exchange.md
+++ b/docs/token-exchange.md
@@ -160,7 +160,7 @@ rest.auth.oauth2.token-exchange.actor-token.grant-type=client_credentials
 rest.auth.oauth2.token-exchange.actor-token.scope=catalog3
 rest.auth.oauth2.token-exchange.actor-token.client-id=Client3
 rest.auth.oauth2.token-exchange.actor-token.client-auth=private_key_jwt
-rest.auth.oauth2.token-exchange.actor-token.client-assertion.jwt.private-key=/path/to/private_key.pem
+rest.auth.oauth2.token-exchange.actor-token.client-auth.jwt.private-key=/path/to/private_key.pem
 ```
 
 In this example:

--- a/oauth2/core/src/docs/java/com/dremio/iceberg/authmgr/oauth2/docs/DocumentationGenerator.java
+++ b/oauth2/core/src/docs/java/com/dremio/iceberg/authmgr/oauth2/docs/DocumentationGenerator.java
@@ -62,6 +62,7 @@ public class DocumentationGenerator {
     refs.put("GrantType#AUTHORIZATION_CODE", "authorization_code");
     refs.put("GrantType#REFRESH_TOKEN", "refresh_token");
     refs.put("GrantType#DEVICE_CODE", "urn:ietf:params:oauth:grant-type:device_code");
+    refs.put("GrantType#JWT_BEARER", "urn:ietf:params:oauth:grant-type:jwt-bearer");
     refs.put("GrantType#TOKEN_EXCHANGE", "urn:ietf:params:oauth:grant-type:token-exchange");
     refs.put("JWSAlgorithm#HS512", "HS512");
     refs.put("JWSAlgorithm#RS512", "RS512");
@@ -229,7 +230,14 @@ public class DocumentationGenerator {
         String className = section.configClass.getPackageName() + "." + parts[0];
         String fieldName = parts[1];
         JavaClass classRef = builder.getClassByName(className);
+        if (classRef == null) {
+          throw new IllegalArgumentException("Unresolved documentation reference: " + ref);
+        }
         Section refSection = sections.get(classRef.getFullyQualifiedName());
+        if (refSection == null) {
+          throw new IllegalArgumentException(
+              "Unsupported external documentation reference: " + ref);
+        }
         refTarget = refSection.refs.get(fieldName);
       }
     }

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
@@ -25,6 +25,7 @@ import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.SCO
 import static com.nimbusds.oauth2.sdk.GrantType.AUTHORIZATION_CODE;
 import static com.nimbusds.oauth2.sdk.GrantType.CLIENT_CREDENTIALS;
 import static com.nimbusds.oauth2.sdk.GrantType.DEVICE_CODE;
+import static com.nimbusds.oauth2.sdk.GrantType.JWT_BEARER;
 import static com.nimbusds.oauth2.sdk.GrantType.PASSWORD;
 import static com.nimbusds.oauth2.sdk.GrantType.TOKEN_EXCHANGE;
 import static com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_BASIC;
@@ -41,6 +42,7 @@ import com.dremio.iceberg.authmgr.oauth2.flow.OAuth2Exception;
 import com.dremio.iceberg.authmgr.oauth2.flow.TokensResult;
 import com.dremio.iceberg.authmgr.oauth2.http.HttpClientType;
 import com.dremio.iceberg.authmgr.oauth2.test.ImmutableTestEnvironment.Builder;
+import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.test.junit.EnumLike;
 import com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension;
@@ -103,7 +105,8 @@ public class OAuth2AgentKeycloakIT {
                 .clientAuthenticationMethod(CLIENT_SECRET_BASIC)
                 .build();
         OAuth2Agent agent = env.newAgent()) {
-      boolean expectRefreshToken = initialGrantType != CLIENT_CREDENTIALS;
+      boolean expectRefreshToken =
+          initialGrantType != CLIENT_CREDENTIALS && initialGrantType != JWT_BEARER;
       assertAgent(agent, CLIENT_ID1, expectRefreshToken);
     }
   }
@@ -122,7 +125,9 @@ public class OAuth2AgentKeycloakIT {
                 .clientAuthenticationMethod(CLIENT_SECRET_POST)
                 .build();
         OAuth2Agent agent = env.newAgent()) {
-      assertAgent(agent, CLIENT_ID1, initialGrantType != CLIENT_CREDENTIALS);
+      boolean expectRefreshToken =
+          initialGrantType != CLIENT_CREDENTIALS && initialGrantType != JWT_BEARER;
+      assertAgent(agent, CLIENT_ID1, expectRefreshToken);
     }
   }
 
@@ -130,7 +135,11 @@ public class OAuth2AgentKeycloakIT {
   void publicClient(
       @Enum HttpClientType httpClientType,
       @EnumLike(
-              excludes = {"client_credentials", "urn:ietf:params:oauth:grant-type:token-exchange"})
+              excludes = {
+                "client_credentials",
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
           GrantType initialGrantType,
       Builder envBuilder)
       throws Exception {
@@ -163,7 +172,9 @@ public class OAuth2AgentKeycloakIT {
                 .clientAuthenticationMethod(CLIENT_SECRET_JWT)
                 .build();
         OAuth2Agent agent = env.newAgent()) {
-      assertAgent(agent, CLIENT_ID3, initialGrantType != CLIENT_CREDENTIALS);
+      boolean expectRefreshToken =
+          initialGrantType != CLIENT_CREDENTIALS && initialGrantType != JWT_BEARER;
+      assertAgent(agent, CLIENT_ID3, expectRefreshToken);
     }
   }
 
@@ -196,7 +207,9 @@ public class OAuth2AgentKeycloakIT {
                 .privateKey(privateKeyPath)
                 .build();
         OAuth2Agent agent = env.newAgent()) {
-      assertAgent(agent, clientId, initialGrantType != CLIENT_CREDENTIALS);
+      boolean expectRefreshToken =
+          initialGrantType != CLIENT_CREDENTIALS && initialGrantType != JWT_BEARER;
+      assertAgent(agent, clientId, expectRefreshToken);
     }
   }
 
@@ -250,7 +263,11 @@ public class OAuth2AgentKeycloakIT {
    */
   @CartesianTest
   void impersonation1(
-      @EnumLike(excludes = "urn:ietf:params:oauth:grant-type:token-exchange")
+      @EnumLike(
+              excludes = {
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
           GrantType subjectGrantType,
       Builder envBuilder)
       throws Exception {
@@ -274,7 +291,11 @@ public class OAuth2AgentKeycloakIT {
   @CartesianTest
   void impersonation2(
       @EnumLike(
-              excludes = {"client_credentials", "urn:ietf:params:oauth:grant-type:token-exchange"})
+              excludes = {
+                "client_credentials",
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
           GrantType subjectGrantType,
       Builder envBuilder)
       throws Exception {
@@ -334,7 +355,11 @@ public class OAuth2AgentKeycloakIT {
    */
   @CartesianTest
   void delegation3(
-      @EnumLike(excludes = "urn:ietf:params:oauth:grant-type:token-exchange")
+      @EnumLike(
+              excludes = {
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
           GrantType subjectGrantType,
       Builder envBuilder)
       throws Exception {
@@ -435,6 +460,22 @@ public class OAuth2AgentKeycloakIT {
             .extracting(ErrorObject::getHTTPStatusCode, ErrorObject::getCode)
             .containsExactly(400, "access_denied");
       }
+    }
+  }
+
+  @Test
+  void jwtBearerInvalidAssertion(Builder envBuilder) {
+    try (TestEnvironment env =
+            envBuilder
+                .grantType(JWT_BEARER)
+                .assertion(TestConstants.SUBJECT_TOKEN /* invalid JWT */)
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      soft.assertThatThrownBy(agent::authenticate)
+          .asInstanceOf(type(OAuth2Exception.class))
+          .extracting(OAuth2Exception::getErrorObject)
+          .extracting(ErrorObject::getHTTPStatusCode, ErrorObject::getCode)
+          .containsExactly(400, "invalid_grant");
     }
   }
 

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
@@ -17,17 +17,18 @@ package com.dremio.iceberg.authmgr.oauth2;
 
 import static com.dremio.iceberg.authmgr.oauth2.OAuth2Config.PREFIX;
 import static com.dremio.iceberg.authmgr.oauth2.config.BasicConfig.CLIENT_AUTH;
-import static com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig.ALGORITHM;
-import static com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig.PRIVATE_KEY;
+import static com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig.ALGORITHM;
+import static com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig.PRIVATE_KEY;
 import static com.dremio.iceberg.authmgr.oauth2.config.ResourceOwnerConfig.PASSWORD;
 import static com.dremio.iceberg.authmgr.oauth2.config.ResourceOwnerConfig.USERNAME;
 
 import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
-import com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.HttpConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ResourceOwnerConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.SystemConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig;
@@ -68,8 +69,11 @@ public interface OAuth2Config {
   @WithName(TokenExchangeConfig.GROUP_NAME)
   TokenExchangeConfig getTokenExchangeConfig();
 
-  @WithName(ClientAssertionConfig.GROUP_NAME)
-  ClientAssertionConfig getClientAssertionConfig();
+  @WithName(JwtBearerConfig.GROUP_NAME)
+  JwtBearerConfig getJwtBearerGrantConfig();
+
+  @WithName(JwtClientAuthConfig.GROUP_NAME)
+  JwtClientAuthConfig getJwtClientAuthConfig();
 
   @WithName(SystemConfig.GROUP_NAME)
   SystemConfig getSystemConfig();
@@ -119,7 +123,8 @@ public interface OAuth2Config {
     getDeviceCodeConfig().validate();
     getTokenRefreshConfig().validate();
     getTokenExchangeConfig().validate();
-    getClientAssertionConfig().validate();
+    getJwtBearerGrantConfig().validate();
+    getJwtClientAuthConfig().validate();
     getSystemConfig().validate();
     getHttpConfig().validate();
     // Validate constraints that span multiple configuration classes
@@ -163,41 +168,52 @@ public interface OAuth2Config {
           getTokenExchangeConfig().getSubjectToken().isPresent()
               || getTokenExchangeConfig().getSubjectTokenFile().isPresent()
               || !getTokenExchangeConfig().getSubjectTokenConfig().isEmpty(),
-          TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.SUBJECT_TOKEN,
-          "subject token must be set if grant type is '%s'",
+          List.of(
+              TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.SUBJECT_TOKEN,
+              TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.SUBJECT_TOKEN_FILE),
+          "either subject token, subject token file or dynamic subject token configuration must be set if grant type is '%s'",
           GrantType.TOKEN_EXCHANGE.getValue());
+    }
+    if (grantType.equals(GrantType.JWT_BEARER)) {
+      validator.check(
+          getJwtBearerGrantConfig().getAssertion().isPresent()
+              || getJwtBearerGrantConfig().getAssertionFile().isPresent()
+              || !getJwtBearerGrantConfig().getAssertionConfig().isEmpty(),
+          List.of(
+              JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION,
+              JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION_FILE),
+          "either assertion, assertion file or dynamic assertion configuration must be set if grant type is '%s'",
+          GrantType.JWT_BEARER.getValue());
     }
     ClientAuthenticationMethod method = getBasicConfig().getClientAuthenticationMethod();
     if (ConfigUtils.requiresJwsAlgorithm(method)) {
       if (method.equals(ClientAuthenticationMethod.CLIENT_SECRET_JWT)) {
-        if (getClientAssertionConfig().getAlgorithm().isPresent()) {
+        if (getJwtClientAuthConfig().getAlgorithm().isPresent()) {
           validator.check(
-              JWSAlgorithm.Family.HMAC_SHA.contains(
-                  getClientAssertionConfig().getAlgorithm().get()),
-              List.of(PREFIX + '.' + CLIENT_AUTH, ClientAssertionConfig.PREFIX + '.' + ALGORITHM),
+              JWSAlgorithm.Family.HMAC_SHA.contains(getJwtClientAuthConfig().getAlgorithm().get()),
+              List.of(PREFIX + '.' + CLIENT_AUTH, JwtClientAuthConfig.PREFIX + '.' + ALGORITHM),
               "client authentication method '%s' is not compatible with JWS algorithm '%s'",
               method.getValue(),
-              getClientAssertionConfig().getAlgorithm().get());
+              getJwtClientAuthConfig().getAlgorithm().get());
         }
         validator.check(
-            getClientAssertionConfig().getPrivateKey().isEmpty(),
-            List.of(PREFIX + '.' + CLIENT_AUTH, ClientAssertionConfig.PREFIX + '.' + PRIVATE_KEY),
+            getJwtClientAuthConfig().getPrivateKey().isEmpty(),
+            List.of(PREFIX + '.' + CLIENT_AUTH, JwtClientAuthConfig.PREFIX + '.' + PRIVATE_KEY),
             "client authentication method '%s' must not have a private key configured",
             method.getValue());
       }
       if (method.equals(ClientAuthenticationMethod.PRIVATE_KEY_JWT)) {
-        if (getClientAssertionConfig().getAlgorithm().isPresent()) {
+        if (getJwtClientAuthConfig().getAlgorithm().isPresent()) {
           validator.check(
-              JWSAlgorithm.Family.SIGNATURE.contains(
-                  getClientAssertionConfig().getAlgorithm().get()),
-              List.of(PREFIX + '.' + CLIENT_AUTH, ClientAssertionConfig.PREFIX + '.' + ALGORITHM),
+              JWSAlgorithm.Family.SIGNATURE.contains(getJwtClientAuthConfig().getAlgorithm().get()),
+              List.of(PREFIX + '.' + CLIENT_AUTH, JwtClientAuthConfig.PREFIX + '.' + ALGORITHM),
               "client authentication method '%s' is not compatible with JWS algorithm '%s'",
               method.getValue(),
-              getClientAssertionConfig().getAlgorithm().get());
+              getJwtClientAuthConfig().getAlgorithm().get());
         }
         validator.check(
-            getClientAssertionConfig().getPrivateKey().isPresent(),
-            List.of(PREFIX + '.' + CLIENT_AUTH, ClientAssertionConfig.PREFIX + '.' + PRIVATE_KEY),
+            getJwtClientAuthConfig().getPrivateKey().isPresent(),
+            List.of(PREFIX + '.' + CLIENT_AUTH, JwtClientAuthConfig.PREFIX + '.' + PRIVATE_KEY),
             "client authentication method '%s' requires a private key",
             method.getValue());
       }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/BasicConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/BasicConfig.java
@@ -109,6 +109,7 @@ public interface BasicConfig {
    *   <li>{@link GrantType#AUTHORIZATION_CODE authorization_code}
    *   <li>{@link GrantType#DEVICE_CODE urn:ietf:params:oauth:grant-type:device_code}
    *   <li>{@link GrantType#TOKEN_EXCHANGE urn:ietf:params:oauth:grant-type:token-exchange}
+   *   <li>{@link GrantType#JWT_BEARER urn:ietf:params:oauth:grant-type:jwt-bearer}
    * </ul>
    *
    * Optional, defaults to {@code client_credentials}.

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptor.java
@@ -48,7 +48,12 @@ public class ConfigRelocationInterceptor implements ConfigSourceInterceptor {
               Pattern.compile("\\.token-exchange\\.audience$"),
               ".token-exchange.audiences",
               Pattern.compile("\\.token-exchange\\.audiences$"),
-              ".token-exchange.audience"));
+              ".token-exchange.audience"),
+          new RelocationRule(
+              Pattern.compile("\\.client-assertion(?=\\.|$)"),
+              ".client-auth",
+              Pattern.compile("\\.client-auth(?=\\.|$)"),
+              ".client-assertion"));
 
   @Override
   public Iterator<String> iterateNames(ConfigSourceInterceptorContext context) {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtils.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtils.java
@@ -30,7 +30,8 @@ public final class ConfigUtils {
           GrantType.PASSWORD,
           GrantType.AUTHORIZATION_CODE,
           GrantType.DEVICE_CODE,
-          GrantType.TOKEN_EXCHANGE);
+          GrantType.TOKEN_EXCHANGE,
+          GrantType.JWT_BEARER);
 
   public static final List<ClientAuthenticationMethod> SUPPORTED_CLIENT_AUTH_METHODS =
       List.of(

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtBearerConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtBearerConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.config;
+
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
+import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
+import io.smallrye.config.WithName;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Configuration properties for the JWT bearer grant as specified in <a
+ * href="https://datatracker.ietf.org/doc/html/rfc7523">RFC 7523</a>.
+ *
+ * <p>The assertion can be supplied statically or fetched dynamically using a nested OAuth2
+ * configuration.
+ */
+public interface JwtBearerConfig {
+
+  String GROUP_NAME = "jwt-bearer";
+  String PREFIX = OAuth2Config.PREFIX + '.' + GROUP_NAME;
+
+  String ASSERTION = "assertion";
+  String ASSERTION_FILE = "assertion-file";
+
+  /**
+   * The assertion to exchange.
+   *
+   * <p>If this value is present, the assertion is used as-is. If this value is not present, the
+   * assertion may be read from the file specified by {@value #ASSERTION_FILE}, or dynamically
+   * fetched using the configuration provided under the {@value #ASSERTION} prefix.
+   */
+  @WithName(ASSERTION)
+  Optional<String> getAssertion();
+
+  /**
+   * Path to a file containing the assertion. The file content is read and trimmed to obtain the
+   * assertion value. Ignored if {@value #ASSERTION} is set.
+   */
+  @WithName(ASSERTION_FILE)
+  Optional<Path> getAssertionFile();
+
+  /**
+   * The configuration to use for fetching the assertion dynamically.
+   *
+   * <p>This is a prefix property; any property that can be set under the {@value
+   * OAuth2Config#PREFIX} prefix can also be set under this prefix.
+   */
+  @WithName(ASSERTION)
+  Map<String, String> getAssertionConfig();
+
+  default void validate() {
+    ConfigValidator validator = new ConfigValidator();
+    Path assertionFilePath = getAssertionFile().orElse(null);
+    if (getAssertion().isEmpty() && assertionFilePath != null) {
+      validator.check(
+          Files.isReadable(assertionFilePath),
+          PREFIX + '.' + ASSERTION_FILE,
+          "jwt-bearer: '%s' is not a file or is not readable",
+          assertionFilePath);
+    }
+    validator.validate();
+  }
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfig.java
@@ -41,9 +41,9 @@ import java.util.stream.Stream;
  * <p>These properties allow the client to authenticate using the {@code client_secret_jwt} or
  * {@code private_key_jwt} authentication methods.
  */
-public interface ClientAssertionConfig {
+public interface JwtClientAuthConfig {
 
-  String GROUP_NAME = "client-assertion.jwt";
+  String GROUP_NAME = "client-auth.jwt";
   String PREFIX = OAuth2Config.PREFIX + '.' + GROUP_NAME;
 
   String ISSUER = "issuer";

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
@@ -199,7 +199,7 @@ abstract class AbstractFlow implements Flow {
     } else if (method.equals(CLIENT_SECRET_JWT)) {
       JWTAssertionDetails details = createJwtAssertionDetails(tokenEndpoint);
       JWSAlgorithm algorithm =
-          getConfig().getClientAssertionConfig().getAlgorithm().orElse(JWSAlgorithm.HS256);
+          getConfig().getJwtClientAuthConfig().getAlgorithm().orElse(JWSAlgorithm.HS256);
       Secret secret = getConfig().getBasicConfig().getClientSecret().orElseThrow();
       try {
         SignedJWT assertion = JWTAssertionFactory.create(details, algorithm, secret);
@@ -211,11 +211,11 @@ abstract class AbstractFlow implements Flow {
     } else if (method.equals(PRIVATE_KEY_JWT)) {
       JWTAssertionDetails details = createJwtAssertionDetails(tokenEndpoint);
       JWSAlgorithm algorithm =
-          getConfig().getClientAssertionConfig().getAlgorithm().orElse(JWSAlgorithm.RS256);
-      Path privateKeyPath = getConfig().getClientAssertionConfig().getPrivateKey().orElseThrow();
+          getConfig().getJwtClientAuthConfig().getAlgorithm().orElse(JWSAlgorithm.RS256);
+      Path privateKeyPath = getConfig().getJwtClientAuthConfig().getPrivateKey().orElseThrow();
       PrivateKey privateKey = PemReader.getInstance().readPrivateKey(privateKeyPath);
       try {
-        String kid = getConfig().getClientAssertionConfig().getKeyId().orElse(null);
+        String kid = getConfig().getJwtClientAuthConfig().getKeyId().orElse(null);
         SignedJWT assertion =
             JWTAssertionFactory.create(details, algorithm, privateKey, kid, null, null, null);
         return new PrivateKeyJWT(assertion);
@@ -229,22 +229,22 @@ abstract class AbstractFlow implements Flow {
 
   private JWTAssertionDetails createJwtAssertionDetails(URI tokenEndpoint) {
     Issuer issuer =
-        getConfig().getClientAssertionConfig().getIssuer().isPresent()
-            ? getConfig().getClientAssertionConfig().getIssuer().get()
+        getConfig().getJwtClientAuthConfig().getIssuer().isPresent()
+            ? getConfig().getJwtClientAuthConfig().getIssuer().get()
             : new Issuer(getConfig().getBasicConfig().getClientId().orElseThrow());
     Subject subject =
-        getConfig().getClientAssertionConfig().getSubject().isPresent()
-            ? getConfig().getClientAssertionConfig().getSubject().get()
+        getConfig().getJwtClientAuthConfig().getSubject().isPresent()
+            ? getConfig().getJwtClientAuthConfig().getSubject().get()
             : new Subject(getConfig().getBasicConfig().getClientId().orElseThrow().getValue());
     List<Audience> audiences =
         getConfig()
-            .getClientAssertionConfig()
+            .getJwtClientAuthConfig()
             .getAudience()
             .orElseGet(() -> List.of(new Audience(tokenEndpoint)));
     Instant issuedAt = getRuntime().getClock().instant();
-    Instant expiration = issuedAt.plus(getConfig().getClientAssertionConfig().getTokenLifespan());
+    Instant expiration = issuedAt.plus(getConfig().getJwtClientAuthConfig().getTokenLifespan());
     @SuppressWarnings({"rawtypes", "unchecked"})
-    Map<String, Object> extraClaims = (Map) getConfig().getClientAssertionConfig().getExtraClaims();
+    Map<String, Object> extraClaims = (Map) getConfig().getJwtClientAuthConfig().getExtraClaims();
     return new JWTAssertionDetails(
         issuer,
         subject,

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowFactory.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowFactory.java
@@ -19,6 +19,7 @@ import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
 import com.dremio.iceberg.authmgr.oauth2.endpoint.EndpointProvider;
 import com.dremio.iceberg.authmgr.oauth2.http.HttpClient;
+import com.dremio.iceberg.authmgr.oauth2.jwtbearer.AssertionSupplier;
 import com.dremio.iceberg.authmgr.oauth2.tokenexchange.ActorTokenSupplier;
 import com.dremio.iceberg.authmgr.oauth2.tokenexchange.SubjectTokenSupplier;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
@@ -64,20 +65,24 @@ public abstract class FlowFactory implements AutoCloseable {
   public void close() {
     SubjectTokenSupplier subjectTokenSupplier = getSubjectTokenSupplier();
     ActorTokenSupplier actorTokenSupplier = getActorTokenSupplier();
+    AssertionSupplier assertionSupplier = getAssertionSupplier();
     HttpClient httpClient = getHttpClient();
     try (httpClient;
         subjectTokenSupplier;
-        actorTokenSupplier) {}
+        actorTokenSupplier;
+        assertionSupplier) {}
   }
 
   public FlowFactory copy() {
     SubjectTokenSupplier subjectTokenSupplier = getSubjectTokenSupplier();
     ActorTokenSupplier actorTokenSupplier = getActorTokenSupplier();
+    AssertionSupplier assertionSupplier = getAssertionSupplier();
     return ImmutableFlowFactory.builder()
         .from(this)
-        // Copy the token suppliers to also create copies of their internal agents.
+        // Copy the suppliers to also create copies of their internal agents.
         .subjectTokenSupplier(subjectTokenSupplier == null ? null : subjectTokenSupplier.copy())
         .actorTokenSupplier(actorTokenSupplier == null ? null : actorTokenSupplier.copy())
+        .assertionSupplier(assertionSupplier == null ? null : assertionSupplier.copy())
         .build();
   }
 
@@ -94,6 +99,14 @@ public abstract class FlowFactory implements AutoCloseable {
   @Value.Default
   protected EndpointProvider getEndpointProvider() {
     return EndpointProvider.create(getConfig(), getHttpClient());
+  }
+
+  @Value.Default
+  @Nullable
+  protected AssertionSupplier getAssertionSupplier() {
+    return !getConfig().getBasicConfig().getGrantType().equals(GrantType.JWT_BEARER)
+        ? null
+        : AssertionSupplier.create(getConfig(), getRuntime());
   }
 
   @Value.Default
@@ -127,6 +140,10 @@ public abstract class FlowFactory implements AutoCloseable {
 
     } else if (grantType.equals(GrantType.DEVICE_CODE)) {
       return ImmutableDeviceCodeFlow.builder();
+
+    } else if (grantType.equals(GrantType.JWT_BEARER)) {
+      return ImmutableJwtBearerFlow.builder()
+          .assertionStage(Objects.requireNonNull(getAssertionSupplier()).supplyAssertionAsync());
 
     } else if (grantType.equals(GrantType.TOKEN_EXCHANGE)) {
       return ImmutableTokenExchangeFlow.builder()

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/JwtBearerFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/JwtBearerFlow.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.flow;
+
+import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.JWTBearerGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * An implementation of the <a href="https://datatracker.ietf.org/doc/html/rfc7523#section-2.1"JWT
+ * bearer</a> grant.
+ */
+@AuthManagerImmutable
+abstract class JwtBearerFlow extends AbstractFlow {
+
+  interface Builder extends AbstractFlow.Builder<JwtBearerFlow, Builder> {
+    @CanIgnoreReturnValue
+    Builder assertionStage(CompletionStage<String> assertionStage);
+  }
+
+  @Override
+  public final GrantType getGrantType() {
+    return GrantType.JWT_BEARER;
+  }
+
+  abstract CompletionStage<String> assertionStage();
+
+  @Override
+  public CompletionStage<TokensResult> fetchNewTokens() {
+    return assertionStage()
+        .thenApply(JwtBearerFlow::toJwtBearerGrant)
+        .thenCompose(this::invokeTokenEndpoint);
+  }
+
+  private static JWTBearerGrant toJwtBearerGrant(String assertion) {
+    Objects.requireNonNull(
+        assertion, "Cannot execute JWT bearer grant: missing required assertion");
+    // Delegate parsing to JWTBearerGrant.parse() so we make no structural assumptions
+    // about the assertion. It handles both signed (JWS) and encrypted (JWE) JWTs,
+    // and rejects unsecured plain JWTs as required by RFC 7523.
+    try {
+      return JWTBearerGrant.parse(
+          Map.of(
+              "grant_type", List.of(GrantType.JWT_BEARER.getValue()),
+              "assertion", List.of(assertion)));
+    } catch (ParseException e) {
+      throw new IllegalArgumentException("Failed to create JWT Bearer grant: " + e.getMessage(), e);
+    }
+  }
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplier.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplier.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.jwtbearer;
+
+import static com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils.prefixedMap;
+
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
+import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2Agent;
+import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.SystemConfig;
+import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.id.Identifier;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.immutables.value.Value;
+
+/** An assertion supplier for assertion grant requests. */
+@AuthManagerImmutable
+public abstract class AssertionSupplier implements AutoCloseable {
+
+  public static AssertionSupplier create(OAuth2Config config, OAuth2AgentRuntime runtime) {
+    return ImmutableAssertionSupplier.builder().mainConfig(config).runtime(runtime).build();
+  }
+
+  /**
+   * Returns a stage that will supply the requested assertion when completed.
+   *
+   * <p>If the assertion is static, the returned stage will be already completed with the assertion
+   * to use. Otherwise, the stage will complete when the underlying agent has completed its
+   * authentication, and its token will become the assertion to use.
+   *
+   * <p>This supplier makes no assumption about the contents of the assertion. Assertions will be
+   * validated later on, when creating the assertion grant.
+   */
+  public CompletionStage<String> supplyAssertionAsync() {
+    if (getAssertionAgent() != null) {
+      return getAssertionAgent().authenticateAsync().thenApply(Identifier::getValue);
+    } else {
+      return CompletableFuture.completedStage(getStaticAssertion().get());
+    }
+  }
+
+  /**
+   * Returns a copy of this supplier. The copy will share the same spec, executor and REST client
+   * supplier as the original supplier, as well as its static assertion, if any. If the assertion is
+   * dynamic, the original agent will be copied.
+   */
+  public AssertionSupplier copy() {
+    return ImmutableAssertionSupplier.builder()
+        .from(this)
+        .assertionAgent(getAssertionAgent() == null ? null : getAssertionAgent().copy())
+        .build();
+  }
+
+  @Value.Check
+  protected void validate() {
+    if (getStaticAssertion().isEmpty() && getAssertionAgentConfig().isEmpty()) {
+      throw new IllegalArgumentException("Assertion is required");
+    }
+  }
+
+  @Value.Default
+  @Nullable
+  protected OAuth2Agent getAssertionAgent() {
+    if (!getMainConfig().getBasicConfig().getGrantType().equals(GrantType.JWT_BEARER)
+        || getStaticAssertion().isPresent()
+        || getAssertionAgentConfig().isEmpty()) {
+      return null;
+    }
+    Map<String, String> assertionAgentProperties = getAssertionAgentConfig();
+    if (!assertionAgentProperties.containsKey(
+        SystemConfig.PREFIX + '.' + SystemConfig.AGENT_NAME)) {
+      assertionAgentProperties = new HashMap<>(assertionAgentProperties);
+      assertionAgentProperties.put(
+          SystemConfig.PREFIX + '.' + SystemConfig.AGENT_NAME, getDefaultAgentName());
+    }
+    OAuth2Config assertionAgentConfig = OAuth2Config.from(assertionAgentProperties);
+    return new OAuth2Agent(assertionAgentConfig, getRuntime());
+  }
+
+  @Override
+  public void close() {
+    if (getAssertionAgent() != null) {
+      getAssertionAgent().close();
+    }
+  }
+
+  @Value.Derived
+  protected Map<String, String> getAssertionAgentConfig() {
+    return prefixedMap(
+        getMainConfig().getJwtBearerGrantConfig().getAssertionConfig(), OAuth2Config.PREFIX);
+  }
+
+  @Value.Derived
+  protected Optional<String> getStaticAssertion() {
+    JwtBearerConfig jwtBearerConfig = getMainConfig().getJwtBearerGrantConfig();
+    return jwtBearerConfig
+        .getAssertion()
+        .or(() -> jwtBearerConfig.getAssertionFile().map(AssertionSupplier::readAssertionFromFile));
+  }
+
+  private static String readAssertionFromFile(Path path) {
+    try {
+      return Files.readString(path).strip();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read assertion from file: " + path, e);
+    }
+  }
+
+  @Value.Derived
+  protected String getDefaultAgentName() {
+    return getMainConfig().getSystemConfig().getAgentName() + "-assertion";
+  }
+
+  protected abstract OAuth2Config getMainConfig();
+
+  protected abstract OAuth2AgentRuntime getRuntime();
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ConfigTest.java
@@ -22,10 +22,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
-import com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ResourceOwnerConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
 import com.google.common.collect.ImmutableMap;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.Secret;
@@ -104,18 +105,22 @@ class OAuth2ConfigTest {
         ImmutableMap.<String, String>builder()
             .put(PREFIX + '.' + BasicConfig.ISSUER_URL, "https://example.com")
             .put(PREFIX + '.' + BasicConfig.CLIENT_ID, "Client")
-            .put(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "w00t")
+            .put(PREFIX + '.' + BasicConfig.CLIENT_AUTH, "private_key_jwt")
             .put(PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.AUTHORIZATION_CODE.getValue())
             .put(PREFIX + ".auth-code.callback-https", "true")
             .put(PREFIX + ".auth-code.callback-bind-host", "example.com")
             .put(PREFIX + ".auth-code.callback-bind-port", "8080")
             .put(PREFIX + ".auth-code.callback-context-path", "/context")
+            .put(PREFIX + ".client-assertion.jwt.algorithm", "RS256")
+            .put(PREFIX + ".client-assertion.jwt.private-key", tempFile.toString())
             .build();
     OAuth2Config config = OAuth2Config.from(properties);
     assertThat(config.getAuthorizationCodeConfig().isCallbackHttps()).isTrue();
     assertThat(config.getAuthorizationCodeConfig().getCallbackBindHost()).hasValue("example.com");
     assertThat(config.getAuthorizationCodeConfig().getCallbackBindPort()).hasValue(8080);
     assertThat(config.getAuthorizationCodeConfig().getCallbackContextPath()).hasValue("/context");
+    assertThat(config.getJwtClientAuthConfig().getAlgorithm()).contains(JWSAlgorithm.RS256);
+    assertThat(config.getJwtClientAuthConfig().getPrivateKey()).contains(tempFile);
   }
 
   @Test
@@ -123,18 +128,22 @@ class OAuth2ConfigTest {
   void testLegacyPrefixRelocationFromSystemProperties() {
     System.setProperty(PREFIX + '.' + BasicConfig.ISSUER_URL, "https://example.com");
     System.setProperty(PREFIX + '.' + BasicConfig.CLIENT_ID, "Client");
-    System.setProperty(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "w00t");
+    System.setProperty(PREFIX + '.' + BasicConfig.CLIENT_AUTH, "private_key_jwt");
     System.setProperty(
         PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.AUTHORIZATION_CODE.getValue());
     System.setProperty(PREFIX + ".auth-code.callback-https", "true");
     System.setProperty(PREFIX + ".auth-code.callback-bind-host", "example.com");
     System.setProperty(PREFIX + ".auth-code.callback-bind-port", "8080");
     System.setProperty(PREFIX + ".auth-code.callback-context-path", "/context");
+    System.setProperty(PREFIX + ".client-assertion.jwt.algorithm", "RS256");
+    System.setProperty(PREFIX + ".client-assertion.jwt.private-key", tempFile.toString());
     OAuth2Config config = OAuth2Config.from(Map.of());
     assertThat(config.getAuthorizationCodeConfig().isCallbackHttps()).isTrue();
     assertThat(config.getAuthorizationCodeConfig().getCallbackBindHost()).hasValue("example.com");
     assertThat(config.getAuthorizationCodeConfig().getCallbackBindPort()).hasValue(8080);
     assertThat(config.getAuthorizationCodeConfig().getCallbackContextPath()).hasValue("/context");
+    assertThat(config.getJwtClientAuthConfig().getAlgorithm()).contains(JWSAlgorithm.RS256);
+    assertThat(config.getJwtClientAuthConfig().getPrivateKey()).contains(tempFile);
   }
 
   @Test
@@ -246,6 +255,30 @@ class OAuth2ConfigTest {
                 "either issuer URL or device authorization endpoint must be set if grant type is 'urn:ietf:params:oauth:grant-type:device_code' (rest.auth.oauth2.issuer-url / rest.auth.oauth2.device-code.endpoint)")),
         Arguments.of(
             Map.of(
+                PREFIX + '.' + BasicConfig.GRANT_TYPE,
+                GrantType.JWT_BEARER.getValue(),
+                PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT,
+                "https://example.com/token",
+                PREFIX + '.' + BasicConfig.CLIENT_ID,
+                "Client1",
+                PREFIX + '.' + BasicConfig.CLIENT_SECRET,
+                "s3cr3t"),
+            List.of(
+                "either assertion, assertion file or dynamic assertion configuration must be set if grant type is 'urn:ietf:params:oauth:grant-type:jwt-bearer' (rest.auth.oauth2.jwt-bearer.assertion / rest.auth.oauth2.jwt-bearer.assertion-file)")),
+        Arguments.of(
+            Map.of(
+                PREFIX + '.' + BasicConfig.GRANT_TYPE,
+                GrantType.TOKEN_EXCHANGE.getValue(),
+                PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT,
+                "https://example.com/token",
+                PREFIX + '.' + BasicConfig.CLIENT_ID,
+                "Client1",
+                PREFIX + '.' + BasicConfig.CLIENT_SECRET,
+                "s3cr3t"),
+            List.of(
+                "either subject token, subject token file or dynamic subject token configuration must be set if grant type is 'urn:ietf:params:oauth:grant-type:token-exchange' (rest.auth.oauth2.token-exchange.subject-token / rest.auth.oauth2.token-exchange.subject-token-file)")),
+        Arguments.of(
+            Map.of(
                 PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT,
                 "https://example.com/token",
                 PREFIX + '.' + BasicConfig.CLIENT_ID,
@@ -254,13 +287,13 @@ class OAuth2ConfigTest {
                 "s3cr3t",
                 PREFIX + '.' + BasicConfig.CLIENT_AUTH,
                 "client_secret_jwt",
-                ClientAssertionConfig.PREFIX + '.' + ClientAssertionConfig.ALGORITHM,
+                JwtClientAuthConfig.PREFIX + '.' + JwtClientAuthConfig.ALGORITHM,
                 "RS256",
-                ClientAssertionConfig.PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY,
+                JwtClientAuthConfig.PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY,
                 tempFile.toString()),
             List.of(
-                "client authentication method 'client_secret_jwt' is not compatible with JWS algorithm 'RS256' (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-assertion.jwt.algorithm)",
-                "client authentication method 'client_secret_jwt' must not have a private key configured (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-assertion.jwt.private-key)")),
+                "client authentication method 'client_secret_jwt' is not compatible with JWS algorithm 'RS256' (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-auth.jwt.algorithm)",
+                "client authentication method 'client_secret_jwt' must not have a private key configured (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-auth.jwt.private-key)")),
         Arguments.of(
             Map.of(
                 PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT,
@@ -269,10 +302,10 @@ class OAuth2ConfigTest {
                 "Client1",
                 PREFIX + '.' + BasicConfig.CLIENT_AUTH,
                 "private_key_jwt",
-                ClientAssertionConfig.PREFIX + '.' + ClientAssertionConfig.ALGORITHM,
+                JwtClientAuthConfig.PREFIX + '.' + JwtClientAuthConfig.ALGORITHM,
                 "HS256"),
             List.of(
-                "client authentication method 'private_key_jwt' is not compatible with JWS algorithm 'HS256' (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-assertion.jwt.algorithm)",
-                "client authentication method 'private_key_jwt' requires a private key (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-assertion.jwt.private-key)")));
+                "client authentication method 'private_key_jwt' is not compatible with JWS algorithm 'HS256' (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-auth.jwt.algorithm)",
+                "client authentication method 'private_key_jwt' requires a private key (rest.auth.oauth2.client-auth / rest.auth.oauth2.client-auth.jwt.private-key)")));
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ManagerTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2ManagerTest.java
@@ -16,6 +16,7 @@
 package com.dremio.iceberg.authmgr.oauth2;
 
 import static com.dremio.iceberg.authmgr.oauth2.OAuth2Config.PREFIX;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.mockito.Mockito.never;
@@ -87,7 +88,7 @@ class OAuth2ManagerTest {
             AuthSession session = manager.catalogSession(client, properties)) {
           HTTPRequest actual = session.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
-              .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
+              .containsOnly(HTTPHeader.of("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL));
         }
       }
     }
@@ -112,13 +113,13 @@ class OAuth2ManagerTest {
             AuthSession session = manager.initSession(httpClient, properties)) {
           HTTPRequest actual = session.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
-              .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
+              .containsOnly(HTTPHeader.of("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL));
         }
         try (HTTPClient httpClient = env.newIcebergRestClientBuilder(Map.of()).build();
             AuthSession session = manager.catalogSession(httpClient, properties)) {
           HTTPRequest actual = session.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
-              .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
+              .containsOnly(HTTPHeader.of("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL));
         }
       }
     }
@@ -228,10 +229,10 @@ class OAuth2ManagerTest {
           assertThat(contextualSession1).isNotSameAs(contextualSession2);
           HTTPRequest actual = contextualSession1.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
-              .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
+              .containsOnly(HTTPHeader.of("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL));
           actual = contextualSession2.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
-              .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
+              .containsOnly(HTTPHeader.of("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL));
         }
       }
     }
@@ -260,9 +261,9 @@ class OAuth2ManagerTest {
                     PREFIX + '.' + BasicConfig.CLIENT_SECRET,
                     TestConstants.CLIENT_SECRET2.getValue(),
                     TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.SUBJECT_TOKEN,
-                    TestConstants.SUBJECT_TOKEN.getValue(),
+                    TestConstants.SUBJECT_TOKEN,
                     TokenExchangeConfig.PREFIX + '.' + TokenExchangeConfig.ACTOR_TOKEN,
-                    TestConstants.ACTOR_TOKEN.getValue()),
+                    TestConstants.ACTOR_TOKEN),
                 Map.of(
                     PREFIX + '.' + BasicConfig.GRANT_TYPE,
                     GrantType.TOKEN_EXCHANGE.getValue(),
@@ -328,7 +329,7 @@ class OAuth2ManagerTest {
             AuthSession session = manager.tableSession(client, signerProperties)) {
           HTTPRequest actual = session.authenticate(request);
           assertThat(actual.headers().entries("Authorization"))
-              .containsOnly(HTTPHeader.of("Authorization", "Bearer access_initial"));
+              .containsOnly(HTTPHeader.of("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL));
         }
       }
     }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentTest.java
@@ -15,6 +15,12 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.agent;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_LIFESPAN;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_REFRESHED;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_REFRESHED;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.SUBJECT_TOKEN;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertAccessToken;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokensResult;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +47,7 @@ import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.test.junit.EnumLike;
 import com.dremio.iceberg.authmgr.oauth2.test.user.UserBehavior;
 import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -96,7 +103,7 @@ class OAuth2AgentTest {
         OAuth2Agent agent = env.newAgent()) {
       TokensResult currentTokens = agent.authenticateInternal();
       assertTokensResult(
-          currentTokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+          currentTokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 
@@ -131,7 +138,7 @@ class OAuth2AgentTest {
         OAuth2Agent agent = env.newAgent()) {
       TokensResult currentTokens = agent.authenticateInternal();
       assertTokensResult(
-          currentTokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+          currentTokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 
@@ -169,7 +176,7 @@ class OAuth2AgentTest {
         OAuth2Agent agent = env.newAgent()) {
       TokensResult currentTokens = agent.authenticateInternal();
       assertTokensResult(
-          currentTokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+          currentTokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 
@@ -223,7 +230,7 @@ class OAuth2AgentTest {
         OAuth2Agent agent = env.newAgent()) {
       TokensResult currentTokens = agent.authenticateInternal();
       assertTokensResult(
-          currentTokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+          currentTokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 
@@ -278,7 +285,10 @@ class OAuth2AgentTest {
       TokensResult refreshedTokens =
           agent.refreshCurrentTokens(firstTokens).toCompletableFuture().get();
       assertTokensResult(
-          refreshedTokens, "access_refreshed", "refresh_refreshed", returnRefreshTokenLifespan);
+          refreshedTokens,
+          ACCESS_TOKEN_REFRESHED,
+          REFRESH_TOKEN_REFRESHED,
+          returnRefreshTokenLifespan);
     }
   }
 
@@ -289,7 +299,7 @@ class OAuth2AgentTest {
       // no refresh token
       TokensResult currentTokens =
           TokensResult.of(
-              new Tokens(new BearerAccessToken("access_initial"), null),
+              new Tokens(new BearerAccessToken(ACCESS_TOKEN_INITIAL), null),
               TestConstants.NOW,
               Map.of());
       assertThat(agent.refreshCurrentTokens(currentTokens))
@@ -300,7 +310,8 @@ class OAuth2AgentTest {
       currentTokens =
           TokensResult.of(
               new Tokens(
-                  new BearerAccessToken("access_initial"), new RefreshToken("refresh_initial")),
+                  new BearerAccessToken(ACCESS_TOKEN_INITIAL),
+                  new RefreshToken(REFRESH_TOKEN_INITIAL)),
               TestConstants.NOW,
               Map.of());
       assertThat(agent.refreshCurrentTokens(currentTokens)).isNotCompletedExceptionally();
@@ -308,7 +319,8 @@ class OAuth2AgentTest {
       currentTokens =
           TokensResult.of(
               new Tokens(
-                  new BearerAccessToken("access_initial"), new RefreshToken("refresh_initial")),
+                  new BearerAccessToken(ACCESS_TOKEN_INITIAL),
+                  new RefreshToken(REFRESH_TOKEN_INITIAL)),
               TestConstants.NOW,
               Map.of("refresh_expires_in", 0L));
       assertThat(agent.refreshCurrentTokens(currentTokens)).isNotCompletedExceptionally();
@@ -317,7 +329,8 @@ class OAuth2AgentTest {
       currentTokens =
           TokensResult.of(
               new Tokens(
-                  new BearerAccessToken("access_initial"), new RefreshToken("refresh_initial")),
+                  new BearerAccessToken(ACCESS_TOKEN_INITIAL),
+                  new RefreshToken(REFRESH_TOKEN_INITIAL)),
               TestConstants.NOW,
               Map.of("refresh_expires_in", 5L));
       assertThat(agent.refreshCurrentTokens(currentTokens))
@@ -328,7 +341,8 @@ class OAuth2AgentTest {
       currentTokens =
           TokensResult.of(
               new Tokens(
-                  new BearerAccessToken("access_initial"), new RefreshToken("refresh_initial")),
+                  new BearerAccessToken(ACCESS_TOKEN_INITIAL),
+                  new RefreshToken(REFRESH_TOKEN_INITIAL)),
               TestConstants.NOW,
               Map.of("refresh_expires_in", 6L));
       assertThat(agent.refreshCurrentTokens(currentTokens)).isNotCompletedExceptionally();
@@ -351,10 +365,10 @@ class OAuth2AgentTest {
         OAuth2Agent agent = env.newAgent()) {
       TokensResult currentTokens = agent.authenticateInternal();
       assertTokensResult(
-          currentTokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+          currentTokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
       if (returnRefreshTokens) {
         currentTokens = agent.refreshCurrentTokens(currentTokens).toCompletableFuture().get();
-        assertTokensResult(currentTokens, "access_refreshed", "refresh_refreshed");
+        assertTokensResult(currentTokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
       }
     }
   }
@@ -364,7 +378,11 @@ class OAuth2AgentTest {
       @Enum HttpClientType httpClientType,
       @EnumLike ClientAuthenticationMethod authenticationMethod,
       @Values(booleans = {true, false}) boolean returnRefreshTokens,
-      @EnumLike(excludes = "urn:ietf:params:oauth:grant-type:token-exchange")
+      @EnumLike(
+              excludes = {
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
           GrantType subjectGrantType)
       throws InterruptedException, ExecutionException {
     assumeTrue(
@@ -381,10 +399,11 @@ class OAuth2AgentTest {
                 .build();
         OAuth2Agent agent = env.newAgent()) {
       TokensResult tokens = agent.authenticateInternal();
-      assertTokensResult(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
       if (returnRefreshTokens) {
         tokens = agent.refreshCurrentTokens(tokens).toCompletableFuture().get();
-        assertTokensResult(tokens, "access_refreshed", "refresh_refreshed");
+        assertTokensResult(tokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
       }
     }
   }
@@ -394,7 +413,11 @@ class OAuth2AgentTest {
       @Enum HttpClientType httpClientType,
       @EnumLike ClientAuthenticationMethod authenticationMethod,
       @Values(booleans = {true, false}) boolean returnRefreshTokens,
-      @EnumLike(excludes = "urn:ietf:params:oauth:grant-type:token-exchange")
+      @EnumLike(
+              excludes = {
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
           GrantType actorGrantType)
       throws InterruptedException, ExecutionException {
     assumeTrue(
@@ -411,10 +434,11 @@ class OAuth2AgentTest {
                 .build();
         OAuth2Agent agent = env.newAgent()) {
       TokensResult tokens = agent.authenticateInternal();
-      assertTokensResult(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
       if (returnRefreshTokens) {
         tokens = agent.refreshCurrentTokens(tokens).toCompletableFuture().get();
-        assertTokensResult(tokens, "access_refreshed", "refresh_refreshed");
+        assertTokensResult(tokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
       }
     }
   }
@@ -458,16 +482,111 @@ class OAuth2AgentTest {
   }
 
   @CartesianTest
+  void testJwtBearerStaticAssertion(
+      @Enum HttpClientType httpClientType,
+      @EnumLike ClientAuthenticationMethod authenticationMethod,
+      @Values(booleans = {true, false}) boolean returnRefreshTokens)
+      throws ExecutionException, InterruptedException {
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .grantType(GrantType.JWT_BEARER)
+                .httpClientType(httpClientType)
+                .clientAuthenticationMethod(authenticationMethod)
+                .returnRefreshTokens(returnRefreshTokens)
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      TokensResult currentTokens = agent.authenticateInternal();
+      assertTokensResult(
+          currentTokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
+      if (returnRefreshTokens) {
+        currentTokens = agent.refreshCurrentTokens(currentTokens).toCompletableFuture().get();
+        assertTokensResult(currentTokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
+      }
+    }
+  }
+
+  @CartesianTest
+  void testJwtBearerDynamicAssertion(
+      @Enum HttpClientType httpClientType,
+      @EnumLike ClientAuthenticationMethod authenticationMethod,
+      @Values(booleans = {true, false}) boolean returnRefreshTokens,
+      @EnumLike(
+              excludes = {
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
+          GrantType assertionGrantType)
+      throws InterruptedException, ExecutionException {
+    assumeTrue(
+        !assertionGrantType.equals(GrantType.CLIENT_CREDENTIALS)
+            || !authenticationMethod.equals(ClientAuthenticationMethod.NONE));
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .grantType(GrantType.JWT_BEARER)
+                .httpClientType(httpClientType)
+                .assertion(null)
+                .assertionGrantType(assertionGrantType)
+                .clientAuthenticationMethod(authenticationMethod)
+                .returnRefreshTokens(returnRefreshTokens)
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      TokensResult tokens = agent.authenticateInternal();
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
+      if (returnRefreshTokens) {
+        tokens = agent.refreshCurrentTokens(tokens).toCompletableFuture().get();
+        assertTokensResult(tokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
+      }
+    }
+  }
+
+  @Test
+  void testJwtBearerAssertionNotJwt() {
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .grantType(GrantType.JWT_BEARER)
+                .assertion("NotAValidJWT")
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      soft.assertThatThrownBy(agent::authenticate)
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Cannot acquire a valid OAuth2 access token")
+          .rootCause()
+          .isInstanceOf(ParseException.class)
+          .hasMessageContaining("The assertion is not a JWT");
+    }
+  }
+
+  @Test
+  void testJwtBearerAssertionInvalid() {
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .grantType(GrantType.JWT_BEARER)
+                .assertion(SUBJECT_TOKEN /* invalid JWT */)
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      soft.assertThatThrownBy(agent::authenticate)
+          .asInstanceOf(throwable(OAuth2Exception.class))
+          .extracting(OAuth2Exception::getErrorObject)
+          .satisfies(
+              r -> {
+                soft.assertThat(r.getCode()).isEqualTo("invalid_request");
+                soft.assertThat(r.getDescription()).contains("Invalid request");
+              });
+    }
+  }
+
+  @CartesianTest
   @EnumSource(HttpClientType.class)
   void testStaticToken(@Enum HttpClientType httpClientType) {
     try (TestEnvironment env =
             TestEnvironment.builder()
                 .httpClientType(httpClientType)
-                .token(new TypelessAccessToken("access_initial"))
+                .token(new TypelessAccessToken(ACCESS_TOKEN_INITIAL))
                 .build();
         OAuth2Agent agent = env.newAgent()) {
       TokensResult tokens = agent.authenticateInternal();
-      assertAccessToken(tokens.getTokens().getAccessToken(), "access_initial", 0);
+      assertAccessToken(tokens.getTokens().getAccessToken(), ACCESS_TOKEN_INITIAL, 0);
       // Cannot refresh a static token as there is no refresh token
       soft.assertThat(agent.refreshCurrentTokens(tokens))
           .completesExceptionallyWithin(Duration.ofSeconds(10))
@@ -533,7 +652,7 @@ class OAuth2AgentTest {
 
       try (OAuth2Agent agent = env.newAgent()) {
         TokensResult currentTokens = agent.authenticateInternal();
-        assertTokensResult(currentTokens, "access_initial", null);
+        assertTokensResult(currentTokens, ACCESS_TOKEN_INITIAL, null);
       }
 
       proxyServer.verify(request().withMethod("POST"), atLeast(1));
@@ -574,7 +693,7 @@ class OAuth2AgentTest {
 
       try (OAuth2Agent agent = env.newAgent()) {
         TokensResult currentTokens = agent.authenticateInternal();
-        assertTokensResult(currentTokens, "access_initial", null);
+        assertTokensResult(currentTokens, ACCESS_TOKEN_INITIAL, null);
       }
 
       proxyServer.verify(
@@ -599,7 +718,7 @@ class OAuth2AgentTest {
                 .build();
         OAuth2Agent agent1 = env.newAgent()) {
       TokensResult tokens = agent1.authenticateInternal();
-      assertTokensResult(tokens, "access_initial", "refresh_initial");
+      assertTokensResult(tokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
       // 1) Test copy before close
       try (OAuth2Agent agent2 = agent1.copy()) {
         // Should have the same tokens instance
@@ -613,10 +732,10 @@ class OAuth2AgentTest {
         // Should be able to refresh tokens
         TokensResult refreshedTokens =
             agent2.refreshCurrentTokens(tokens).toCompletableFuture().get();
-        assertTokensResult(refreshedTokens, "access_refreshed", "refresh_refreshed");
+        assertTokensResult(refreshedTokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
         // Should be able to fetch new tokens
         TokensResult newTokens = agent2.fetchNewTokens().toCompletableFuture().get();
-        assertTokensResult(newTokens, "access_initial", "refresh_initial");
+        assertTokensResult(newTokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
       }
       // 2) Test copy after close
       try (OAuth2Agent agent3 = agent1.copy()) {
@@ -627,10 +746,10 @@ class OAuth2AgentTest {
         // Should be able to refresh tokens
         TokensResult refreshedTokens =
             agent3.refreshCurrentTokens(tokens).toCompletableFuture().get();
-        assertTokensResult(refreshedTokens, "access_refreshed", "refresh_refreshed");
+        assertTokensResult(refreshedTokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
         // Should be able to fetch new tokens
         TokensResult newTokens = agent3.fetchNewTokens().toCompletableFuture().get();
-        assertTokensResult(newTokens, "access_initial", "refresh_initial");
+        assertTokensResult(newTokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
       }
     }
   }
@@ -666,31 +785,31 @@ class OAuth2AgentTest {
           agent1.close();
           // Should still have tokens
           TokensResult tokens = agent2.authenticateInternal();
-          assertTokensResult(tokens, "access_initial", "refresh_initial");
+          assertTokensResult(tokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
           soft.assertThat(tokens).isNotNull();
           // Should have a token refresh future
           soft.assertThat(agent2).extracting("tokenRefreshFuture").isNotNull();
           // Should be able to refresh tokens
           TokensResult refreshedTokens =
               agent2.refreshCurrentTokens(tokens).toCompletableFuture().get();
-          assertTokensResult(refreshedTokens, "access_refreshed", "refresh_refreshed");
+          assertTokensResult(refreshedTokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
           // Should be able to fetch new tokens
           TokensResult newTokens = agent2.fetchNewTokens().toCompletableFuture().get();
-          assertTokensResult(newTokens, "access_initial", "refresh_initial");
+          assertTokensResult(newTokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
         }
         // 2) Test copy after close
         try (OAuth2Agent agent3 = agent1.copy()) {
           // Should be able to fetch tokens even if the original agent failed
           TokensResult tokens = agent3.authenticateInternal();
-          assertTokensResult(tokens, "access_initial", "refresh_initial");
+          assertTokensResult(tokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
           soft.assertThat(tokens).isNotNull();
           // Should be able to refresh tokens
           TokensResult refreshedTokens =
               agent3.refreshCurrentTokens(tokens).toCompletableFuture().get();
-          assertTokensResult(refreshedTokens, "access_refreshed", "refresh_refreshed");
+          assertTokensResult(refreshedTokens, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED);
           // Should be able to fetch new tokens
           TokensResult newTokens = agent3.fetchNewTokens().toCompletableFuture().get();
-          assertTokensResult(newTokens, "access_initial", "refresh_initial");
+          assertTokensResult(newTokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
         }
       }
     }
@@ -709,14 +828,14 @@ class OAuth2AgentTest {
 
       // should fetch the initial token
       AccessToken token = agent.authenticate();
-      soft.assertThat(token.getValue()).isEqualTo("access_initial");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_INITIAL);
 
       // emulate executor running the scheduled renewal task
       currentRenewalTask.get().run();
 
       // should have refreshed the token
       token = agent.authenticate();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED);
 
       Duration idleTimeout =
           env.getOAuth2Config().getTokenRefreshConfig().getIdleTimeout().plusSeconds(1);
@@ -728,7 +847,7 @@ class OAuth2AgentTest {
 
       // should exit sleeping mode on next authenticate() call and schedule a token refresh
       token = agent.authenticate();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED);
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isFalse();
 
       // emulate executor running the scheduled renewal task and detecting that the agent is idle
@@ -739,9 +858,9 @@ class OAuth2AgentTest {
 
       // should exit sleeping mode on next authenticate() call
       // and refresh tokens immediately because the current ones are expired
-      ((TestClock) env.getClock()).plus(TestConstants.ACCESS_TOKEN_LIFESPAN);
+      ((TestClock) env.getClock()).plus(ACCESS_TOKEN_LIFESPAN);
       token = agent.authenticate();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED);
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isFalse();
     }
   }
@@ -806,16 +925,16 @@ class OAuth2AgentTest {
       // then return the previously fetched token since it's still valid.
       AccessToken token = agent.authenticate();
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isTrue();
-      soft.assertThat(token.getValue()).isEqualTo("access_initial");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_INITIAL);
       soft.assertThat(currentRenewalTask.get()).isNull();
 
       // will wake up, then refresh the token immediately (since it's expired),
       // then reject scheduling the next refresh, then sleep again,
       // then return the newly-fetched token
-      ((TestClock) env.getClock()).plus(TestConstants.ACCESS_TOKEN_LIFESPAN);
+      ((TestClock) env.getClock()).plus(ACCESS_TOKEN_LIFESPAN);
       token = agent.authenticate();
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isTrue();
-      soft.assertThat(token.getValue()).isEqualTo("access_initial");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_INITIAL);
       soft.assertThat(currentRenewalTask.get()).isNull();
     }
   }
@@ -860,7 +979,7 @@ class OAuth2AgentTest {
       soft.assertThat(currentRenewalTask.get()).isNotNull().isNotSameAs(renewalTask);
       renewalTask = currentRenewalTask.get();
       AccessToken token = agent.authenticate();
-      soft.assertThat(token.getValue()).isEqualTo("access_initial");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_INITIAL);
 
       // failure recovery when in sleep mode
 
@@ -879,9 +998,9 @@ class OAuth2AgentTest {
       // => should keep old tokens and schedule another refresh
       env.reset();
       env.createErrorExpectations();
-      ((TestClock) env.getClock()).plus(TestConstants.ACCESS_TOKEN_LIFESPAN);
+      ((TestClock) env.getClock()).plus(ACCESS_TOKEN_LIFESPAN);
       token = agent.authenticate();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed"); // old tokens kept
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED); // old tokens kept
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isFalse();
       soft.assertThat(currentRenewalTask.get()).isNotNull().isNotSameAs(renewalTask);
       renewalTask = currentRenewalTask.get();
@@ -893,7 +1012,7 @@ class OAuth2AgentTest {
       soft.assertThat(currentRenewalTask.get()).isSameAs(renewalTask);
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isTrue();
       token = agent.getCurrentTokens().getTokens().getAccessToken();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed"); // old tokens still kept
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED); // old tokens still kept
 
       // Emulate waking up; old tokens are available so renewal refreshes them,
       // then scheduling next refresh
@@ -901,7 +1020,7 @@ class OAuth2AgentTest {
       env.createExpectations();
       token = agent.authenticate();
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isFalse();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED);
       soft.assertThat(currentRenewalTask.get()).isNotSameAs(renewalTask);
       renewalTask = currentRenewalTask.get();
 
@@ -915,7 +1034,7 @@ class OAuth2AgentTest {
       // Emulate waking up, then rescheduling a refresh since current token is still valid
       token = agent.authenticate();
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isFalse();
-      soft.assertThat(token.getValue()).isEqualTo("access_refreshed");
+      soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED);
       soft.assertThat(currentRenewalTask.get()).isNotSameAs(renewalTask);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/BasicConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/BasicConfigTest.java
@@ -212,7 +212,7 @@ class BasicConfigTest {
                 PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT,
                 "https://example.com/token"),
             singletonList(
-                "grant type must be one of: 'client_credentials', 'password', 'authorization_code', 'urn:ietf:params:oauth:grant-type:device_code', 'urn:ietf:params:oauth:grant-type:token-exchange' (rest.auth.oauth2.grant-type)")),
+                "grant type must be one of: 'client_credentials', 'password', 'authorization_code', 'urn:ietf:params:oauth:grant-type:device_code', 'urn:ietf:params:oauth:grant-type:token-exchange', 'urn:ietf:params:oauth:grant-type:jwt-bearer' (rest.auth.oauth2.grant-type)")),
         Arguments.of(
             Map.of(
                 PREFIX + '.' + BasicConfig.CLIENT_AUTH,

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
@@ -59,6 +59,12 @@ class ConfigRelocationInterceptorTest {
         Arguments.of(
             "rest.auth.oauth2.token-exchange.audiences",
             "rest.auth.oauth2.token-exchange.audiences"),
+        Arguments.of(
+            "rest.auth.oauth2.client-assertion.jwt.private-key",
+            "rest.auth.oauth2.client-auth.jwt.private-key"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.actor-token.client-assertion.jwt.private-key",
+            "rest.auth.oauth2.token-exchange.actor-token.client-auth.jwt.private-key"),
         Arguments.of("some.other.property", "some.other.property"));
   }
 
@@ -89,6 +95,12 @@ class ConfigRelocationInterceptorTest {
             "rest.auth.oauth2.token-exchange.resource", "rest.auth.oauth2.token-exchange.resource"),
         Arguments.of(
             "rest.auth.oauth2.token-exchange.audience", "rest.auth.oauth2.token-exchange.audience"),
+        Arguments.of(
+            "rest.auth.oauth2.client-auth.jwt.private-key",
+            "rest.auth.oauth2.client-assertion.jwt.private-key"),
+        Arguments.of(
+            "rest.auth.oauth2.token-exchange.actor-token.client-auth.jwt.private-key",
+            "rest.auth.oauth2.token-exchange.actor-token.client-assertion.jwt.private-key"),
         Arguments.of("some.other.property", "some.other.property"));
   }
 
@@ -107,11 +119,18 @@ class ConfigRelocationInterceptorTest {
                 new MapBackedConfigSource(
                     "catalog-properties",
                     Map.of(
-                        "rest.auth.oauth2.auth-code.callback-https", "true",
-                        "rest.auth.oauth2.auth-code.callback-bind-port", "8080",
-                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost",
-                        "rest.auth.oauth2.token-exchange.resource", "urn:resource",
-                        "rest.auth.oauth2.token-exchange.audience", "urn:audience"),
+                        "rest.auth.oauth2.auth-code.callback-https",
+                        "true",
+                        "rest.auth.oauth2.auth-code.callback-bind-port",
+                        "8080",
+                        "rest.auth.oauth2.auth-code.callback-bind-host",
+                        "localhost",
+                        "rest.auth.oauth2.token-exchange.resource",
+                        "urn:resource",
+                        "rest.auth.oauth2.token-exchange.audience",
+                        "urn:audience",
+                        "rest.auth.oauth2.client-assertion.jwt.private-key",
+                        "old"),
                     1000) {})
             .build();
     assertThat(StreamSupport.stream(config.getPropertyNames().spliterator(), false).toList())
@@ -120,7 +139,8 @@ class ConfigRelocationInterceptorTest {
             "rest.auth.oauth2.auth-code.callback.bind-port",
             "rest.auth.oauth2.auth-code.callback.bind-host",
             "rest.auth.oauth2.token-exchange.resources",
-            "rest.auth.oauth2.token-exchange.audiences");
+            "rest.auth.oauth2.token-exchange.audiences",
+            "rest.auth.oauth2.client-auth.jwt.private-key");
   }
 
   @Test
@@ -138,11 +158,18 @@ class ConfigRelocationInterceptorTest {
                 new MapBackedConfigSource(
                     "catalog-properties",
                     Map.of(
-                        "rest.auth.oauth2.auth-code.callback-https", "true",
-                        "rest.auth.oauth2.auth-code.callback-bind-port", "8080",
-                        "rest.auth.oauth2.auth-code.callback-bind-host", "localhost",
-                        "rest.auth.oauth2.token-exchange.resource", "urn:resource",
-                        "rest.auth.oauth2.token-exchange.audience", "urn:audience"),
+                        "rest.auth.oauth2.auth-code.callback-https",
+                        "true",
+                        "rest.auth.oauth2.auth-code.callback-bind-port",
+                        "8080",
+                        "rest.auth.oauth2.auth-code.callback-bind-host",
+                        "localhost",
+                        "rest.auth.oauth2.token-exchange.resource",
+                        "urn:resource",
+                        "rest.auth.oauth2.token-exchange.audience",
+                        "urn:audience",
+                        "rest.auth.oauth2.client-assertion.jwt.private-key",
+                        "old-key"),
                     1000) {})
             .build();
     assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.https")).isEqualTo("true");
@@ -154,5 +181,7 @@ class ConfigRelocationInterceptorTest {
         .isEqualTo("urn:resource");
     assertThat(config.getRawValue("rest.auth.oauth2.token-exchange.audiences"))
         .isEqualTo("urn:audience");
+    assertThat(config.getRawValue("rest.auth.oauth2.client-auth.jwt.private-key"))
+        .isEqualTo("old-key");
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/JwtBearerConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/JwtBearerConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.config;
+
+import static com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig.ASSERTION_FILE;
+import static com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig.PREFIX;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JwtBearerConfigTest {
+
+  @Test
+  void testValidateAssertionFile() {
+    Map<String, String> properties =
+        Map.of(PREFIX + '.' + ASSERTION_FILE, "/invalid/assertion-file");
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withMapping(JwtBearerConfig.class, PREFIX)
+            .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
+            .build();
+    JwtBearerConfig config = smallRyeConfig.getConfigMapping(JwtBearerConfig.class, PREFIX);
+    assertThatIllegalArgumentException()
+        .isThrownBy(config::validate)
+        .withMessage(
+            ConfigValidator.buildDescription(
+                singletonList(
+                    "jwt-bearer: '/invalid/assertion-file' is not a file or is not readable ("
+                        + PREFIX
+                        + '.'
+                        + ASSERTION_FILE
+                        + ")")
+                    .stream()));
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfigTest.java
@@ -15,7 +15,7 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.config;
 
-import static com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig.PREFIX;
+import static com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig.PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class ClientAssertionConfigTest {
+class JwtClientAuthConfigTest {
 
   static Path tempFile;
 
@@ -51,11 +51,10 @@ class ClientAssertionConfigTest {
   void testValidate(Map<String, String> properties, List<String> expected) {
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
-            .withMapping(ClientAssertionConfig.class, PREFIX)
+            .withMapping(JwtClientAuthConfig.class, PREFIX)
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
-    ClientAssertionConfig config =
-        smallRyeConfig.getConfigMapping(ClientAssertionConfig.class, PREFIX);
+    JwtClientAuthConfig config = smallRyeConfig.getConfigMapping(JwtClientAuthConfig.class, PREFIX);
     assertThatIllegalArgumentException()
         .isThrownBy(config::validate)
         .withMessage(ConfigValidator.buildDescription(expected.stream()));
@@ -64,51 +63,50 @@ class ClientAssertionConfigTest {
   static Stream<Arguments> testValidate() {
     return Stream.of(
         Arguments.of(
-            Map.of(PREFIX + '.' + ClientAssertionConfig.ALGORITHM, "RS256"),
+            Map.of(PREFIX + '.' + JwtClientAuthConfig.ALGORITHM, "RS256"),
             List.of(
                 "client assertion: JWS signing algorithm 'RS256' requires a private key "
-                    + "(rest.auth.oauth2.client-assertion.jwt.algorithm / rest.auth.oauth2.client-assertion.jwt.private-key)")),
+                    + "(rest.auth.oauth2.client-auth.jwt.algorithm / rest.auth.oauth2.client-auth.jwt.private-key)")),
         Arguments.of(
             Map.of(
-                PREFIX + '.' + ClientAssertionConfig.ALGORITHM,
+                PREFIX + '.' + JwtClientAuthConfig.ALGORITHM,
                 "HS256",
-                PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY,
+                PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY,
                 tempFile.toString()),
             List.of(
                 "client assertion: private key must not be set for JWS algorithm 'HS256' "
-                    + "(rest.auth.oauth2.client-assertion.jwt.algorithm / rest.auth.oauth2.client-assertion.jwt.private-key)")),
+                    + "(rest.auth.oauth2.client-auth.jwt.algorithm / rest.auth.oauth2.client-auth.jwt.private-key)")),
         Arguments.of(
             Map.of(
-                PREFIX + '.' + ClientAssertionConfig.ALGORITHM,
+                PREFIX + '.' + JwtClientAuthConfig.ALGORITHM,
                 "RSA_SHA256",
-                PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY,
+                PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY,
                 tempFile.toString()),
             List.of(
                 "client assertion: unsupported JWS algorithm 'RSA_SHA256', must be one of: "
                     + "'HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES256K', 'ES384', 'ES512', 'EdDSA', 'Ed25519', 'Ed448' "
-                    + "(rest.auth.oauth2.client-assertion.jwt.algorithm)")),
+                    + "(rest.auth.oauth2.client-auth.jwt.algorithm)")),
         Arguments.of(
-            Map.of(PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY, "/invalid/path"),
+            Map.of(PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY, "/invalid/path"),
             List.of(
                 "client assertion: private key path '/invalid/path' is not a file or is not readable "
-                    + "(rest.auth.oauth2.client-assertion.jwt.private-key)")));
+                    + "(rest.auth.oauth2.client-auth.jwt.private-key)")));
   }
 
   @Test
   void testKeyIdOptional() {
     Map<String, String> properties =
         Map.of(
-            PREFIX + '.' + ClientAssertionConfig.ALGORITHM,
+            PREFIX + '.' + JwtClientAuthConfig.ALGORITHM,
             "RS256",
-            PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY,
+            PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY,
             tempFile.toString());
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
-            .withMapping(ClientAssertionConfig.class, PREFIX)
+            .withMapping(JwtClientAuthConfig.class, PREFIX)
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
-    ClientAssertionConfig config =
-        smallRyeConfig.getConfigMapping(ClientAssertionConfig.class, PREFIX);
+    JwtClientAuthConfig config = smallRyeConfig.getConfigMapping(JwtClientAuthConfig.class, PREFIX);
     assertThat(config.getKeyId()).isEmpty();
   }
 
@@ -116,30 +114,28 @@ class ClientAssertionConfigTest {
   void testKeyIdPresent() {
     Map<String, String> properties =
         Map.of(
-            PREFIX + '.' + ClientAssertionConfig.ALGORITHM, "RS256",
-            PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY, tempFile.toString(),
-            PREFIX + '.' + ClientAssertionConfig.KEY_ID, "my-key-123");
+            PREFIX + '.' + JwtClientAuthConfig.ALGORITHM, "RS256",
+            PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY, tempFile.toString(),
+            PREFIX + '.' + JwtClientAuthConfig.KEY_ID, "my-key-123");
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
-            .withMapping(ClientAssertionConfig.class, PREFIX)
+            .withMapping(JwtClientAuthConfig.class, PREFIX)
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
-    ClientAssertionConfig config =
-        smallRyeConfig.getConfigMapping(ClientAssertionConfig.class, PREFIX);
+    JwtClientAuthConfig config = smallRyeConfig.getConfigMapping(JwtClientAuthConfig.class, PREFIX);
     assertThat(config.getKeyId()).hasValue("my-key-123");
   }
 
   @Test
   void testAudienceSingleValue() {
     Map<String, String> properties =
-        Map.of(PREFIX + '.' + ClientAssertionConfig.AUDIENCE, "https://example.com");
+        Map.of(PREFIX + '.' + JwtClientAuthConfig.AUDIENCE, "https://example.com");
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
-            .withMapping(ClientAssertionConfig.class, PREFIX)
+            .withMapping(JwtClientAuthConfig.class, PREFIX)
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
-    ClientAssertionConfig config =
-        smallRyeConfig.getConfigMapping(ClientAssertionConfig.class, PREFIX);
+    JwtClientAuthConfig config = smallRyeConfig.getConfigMapping(JwtClientAuthConfig.class, PREFIX);
     assertThat(config.getAudience()).contains(List.of(new Audience("https://example.com")));
   }
 
@@ -147,15 +143,14 @@ class ClientAssertionConfigTest {
   void testAudienceMultipleValues() {
     Map<String, String> properties =
         Map.of(
-            PREFIX + '.' + ClientAssertionConfig.AUDIENCE,
+            PREFIX + '.' + JwtClientAuthConfig.AUDIENCE,
             "https://auth1.example.com,https://auth2.example.com");
     SmallRyeConfig smallRyeConfig =
         new SmallRyeConfigBuilder()
-            .withMapping(ClientAssertionConfig.class, PREFIX)
+            .withMapping(JwtClientAuthConfig.class, PREFIX)
             .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
             .build();
-    ClientAssertionConfig config =
-        smallRyeConfig.getConfigMapping(ClientAssertionConfig.class, PREFIX);
+    JwtClientAuthConfig config = smallRyeConfig.getConfigMapping(JwtClientAuthConfig.class, PREFIX);
     assertThat(config.getAudience())
         .contains(
             List.of(

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/ClientCredentialsFlowTest.java
@@ -15,6 +15,7 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokensResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,7 +36,7 @@ class ClientCredentialsFlowTest {
       Flow flow = flowFactory.createInitialFlow();
       assertThat(flow).isInstanceOf(ClientCredentialsFlow.class);
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokensResult(tokens, "access_initial", null);
+      assertTokensResult(tokens, ACCESS_TOKEN_INITIAL, null);
     }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DeviceCodeFlowTest.java
@@ -15,6 +15,8 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokensResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,7 +45,8 @@ class DeviceCodeFlowTest {
       Flow flow = flowFactory.createInitialFlow();
       assertThat(flow).isInstanceOf(DeviceCodeFlow.class);
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokensResult(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/JwtBearerFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/JwtBearerFlowTest.java
@@ -23,39 +23,60 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.test.junit.EnumLike;
 import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
-import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Objects;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
-import org.apache.http.ssl.SSLContextBuilder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 
-class AuthorizationCodeFlowTest {
+class JwtBearerFlowTest {
 
   @CartesianTest
   void fetchNewTokens(
       @EnumLike ClientAuthenticationMethod authenticationMethod,
-      @Values(booleans = {true, false}) boolean pkceEnabled,
-      @EnumLike CodeChallengeMethod codeChallengeMethod,
       @Values(booleans = {true, false}) boolean returnRefreshTokens)
       throws InterruptedException, ExecutionException {
     try (TestEnvironment env =
             TestEnvironment.builder()
-                .grantType(GrantType.AUTHORIZATION_CODE)
+                .grantType(GrantType.JWT_BEARER)
                 .clientAuthenticationMethod(authenticationMethod)
-                .pkceEnabled(pkceEnabled)
-                .codeChallengeMethod(codeChallengeMethod)
                 .returnRefreshTokens(returnRefreshTokens)
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      assertThat(flow).isInstanceOf(AuthorizationCodeFlow.class);
+      assertThat(flow).isInstanceOf(JwtBearerFlow.class);
+      TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
+    }
+  }
+
+  @CartesianTest
+  void fetchNewTokensDynamic(
+      @EnumLike(excludes = {"none", "client_secret_basic"})
+          ClientAuthenticationMethod authenticationMethod,
+      @Values(booleans = {true, false}) boolean returnRefreshTokens,
+      @EnumLike(
+              excludes = {
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "urn:ietf:params:oauth:grant-type:token-exchange"
+              })
+          GrantType assertionGrantType)
+      throws InterruptedException, ExecutionException {
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .grantType(GrantType.JWT_BEARER)
+                .clientAuthenticationMethod(authenticationMethod)
+                .executorPoolSize(2)
+                .returnRefreshTokens(returnRefreshTokens)
+                .assertion(null)
+                .assertionGrantType(assertionGrantType)
+                .build();
+        FlowFactory flowFactory = env.newFlowFactory()) {
+      Flow flow = flowFactory.createInitialFlow();
+      assertThat(flow).isInstanceOf(JwtBearerFlow.class);
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertTokensResult(
           tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
@@ -63,28 +84,22 @@ class AuthorizationCodeFlowTest {
   }
 
   @Test
-  void httpsCallback(@TempDir Path tempDir) throws Exception {
-    Path keyStorePath = tempDir.resolve("keystore.p12");
-    try (InputStream is = getClass().getResourceAsStream("/openssl/mockserver.p12")) {
-      Files.copy(Objects.requireNonNull(is), keyStorePath);
-    }
+  void fetchNewTokensInvalidAssertion() {
     try (TestEnvironment env =
             TestEnvironment.builder()
-                .grantType(GrantType.AUTHORIZATION_CODE)
-                .callbackHttps(true)
-                .sslKeyStorePath(keyStorePath)
-                .sslKeyStorePassword("s3cr3t")
-                .sslKeyStoreAlias("1")
-                .userSslContext(
-                    SSLContextBuilder.create()
-                        .loadTrustMaterial(keyStorePath.toFile(), "s3cr3t".toCharArray())
-                        .build())
+                .grantType(GrantType.JWT_BEARER)
+                .assertion("InvalidJWT")
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       Flow flow = flowFactory.createInitialFlow();
-      assertThat(flow).isInstanceOf(AuthorizationCodeFlow.class);
-      TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokensResult(tokens, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL);
+      assertThat(flow).isInstanceOf(JwtBearerFlow.class);
+      assertThat(flow.fetchNewTokens())
+          .completesExceptionallyWithin(Duration.ofSeconds(30))
+          .withThrowableOfType(ExecutionException.class)
+          .withCauseInstanceOf(IllegalArgumentException.class)
+          .withRootCauseInstanceOf(ParseException.class)
+          .withMessageContaining("Failed to create JWT Bearer grant")
+          .withMessageContaining("The assertion is not a JWT");
     }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/PasswordFlowTest.java
@@ -15,6 +15,8 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokensResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,7 +45,8 @@ class PasswordFlowTest {
       Flow flow = flowFactory.createInitialFlow();
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertThat(flow).isInstanceOf(PasswordFlow.class);
-      assertTokensResult(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/RefreshTokenFlowTest.java
@@ -15,6 +15,9 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_REFRESHED;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_REFRESHED;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokensResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -45,13 +48,13 @@ class RefreshTokenFlowTest {
                 .build();
         FlowFactory flowFactory = env.newFlowFactory()) {
       assumeTrue(returnRefreshTokens || !returnRefreshTokenLifespan);
-      Flow flow = flowFactory.createTokenRefreshFlow(new RefreshToken("refresh_initial"));
+      Flow flow = flowFactory.createTokenRefreshFlow(new RefreshToken(REFRESH_TOKEN_INITIAL));
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
       assertThat(flow).isInstanceOf(RefreshTokenFlow.class);
       assertTokensResult(
           tokens,
-          "access_refreshed",
-          returnRefreshTokens ? "refresh_refreshed" : "refresh_initial",
+          ACCESS_TOKEN_REFRESHED,
+          returnRefreshTokens ? REFRESH_TOKEN_REFRESHED : REFRESH_TOKEN_INITIAL,
           returnRefreshTokenLifespan);
     }
   }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/TokenExchangeFlowTest.java
@@ -15,6 +15,8 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.flow;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
 import static com.dremio.iceberg.authmgr.oauth2.test.TokenAssertions.assertTokensResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,7 +54,8 @@ class TokenExchangeFlowTest {
       Flow flow = flowFactory.createInitialFlow();
       assertThat(flow).isInstanceOf(TokenExchangeFlow.class);
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokensResult(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 
@@ -89,7 +92,8 @@ class TokenExchangeFlowTest {
       Flow flow = flowFactory.createInitialFlow();
       assertThat(flow).isInstanceOf(TokenExchangeFlow.class);
       TokensResult tokens = flow.fetchNewTokens().toCompletableFuture().get();
-      assertTokensResult(tokens, "access_initial", returnRefreshTokens ? "refresh_initial" : null);
+      assertTokensResult(
+          tokens, ACCESS_TOKEN_INITIAL, returnRefreshTokens ? REFRESH_TOKEN_INITIAL : null);
     }
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplierTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplierTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.jwtbearer;
+
+import static com.dremio.iceberg.authmgr.oauth2.OAuth2Config.PREFIX;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ASSERTION_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
+import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
+import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig;
+import com.google.common.collect.ImmutableMap;
+import com.nimbusds.oauth2.sdk.GrantType;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AssertionSupplierTest {
+
+  @Test
+  void testSupplyAssertionAsyncStatic() {
+    OAuth2Config config = createMainConfig(ASSERTION_TOKEN, null, Map.of());
+    try (AssertionSupplier supplier = createSupplier(config)) {
+      CompletionStage<String> stage = supplier.supplyAssertionAsync();
+      assertThat(stage).isCompleted();
+      assertThat(stage.toCompletableFuture().join()).isEqualTo(ASSERTION_TOKEN);
+    }
+  }
+
+  @Test
+  void testSupplyAssertionAsyncDynamic() {
+    OAuth2Config config =
+        createMainConfig(
+            null,
+            null,
+            Map.of(
+                BasicConfig.GRANT_TYPE,
+                GrantType.CLIENT_CREDENTIALS.getValue(),
+                BasicConfig.TOKEN_ENDPOINT,
+                "https://example.com/token",
+                BasicConfig.CLIENT_ID,
+                "test-client",
+                BasicConfig.CLIENT_SECRET,
+                "test-secret"));
+    try (AssertionSupplier supplier = createSupplier(config)) {
+      CompletionStage<String> stage = supplier.supplyAssertionAsync();
+      assertThat(stage).isNotCompleted();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  void testValidate() {
+    OAuth2Config config = createInvalidMainConfig();
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> createSupplier(config))
+        .withMessage("Assertion is required");
+  }
+
+  @Test
+  void testSupplyAssertionAsyncFromFile(@TempDir Path tempDir) throws Exception {
+    Path assertionFile = tempDir.resolve("assertion.txt");
+    Files.writeString(assertionFile, "  " + ASSERTION_TOKEN + "  ");
+    OAuth2Config config = createMainConfig(null, assertionFile, Map.of());
+    try (AssertionSupplier supplier = createSupplier(config)) {
+      CompletionStage<String> stage = supplier.supplyAssertionAsync();
+      assertThat(stage).isCompleted();
+      assertThat(stage.toCompletableFuture().join()).isEqualTo(ASSERTION_TOKEN);
+    }
+  }
+
+  private static OAuth2Config createMainConfig(
+      String assertion, Path assertionFile, Map<String, String> assertionConfig) {
+    return OAuth2Config.from(createProperties(assertion, assertionFile, assertionConfig));
+  }
+
+  private static OAuth2Config createInvalidMainConfig() {
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withSources(
+                new MapBackedConfigSource(
+                    "catalog properties", createProperties(null, null, Map.of()), 200) {})
+            .withMapping(OAuth2Config.class)
+            .build();
+    return smallRyeConfig.getConfigMapping(OAuth2Config.class);
+  }
+
+  private static Map<String, String> createProperties(
+      String assertion, Path assertionFile, Map<String, String> assertionConfig) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+    builder.put(PREFIX + '.' + BasicConfig.GRANT_TYPE, GrantType.JWT_BEARER.getValue());
+    builder.put(PREFIX + '.' + BasicConfig.TOKEN_ENDPOINT, "https://example.com/token");
+    builder.put(PREFIX + '.' + BasicConfig.CLIENT_ID, "test-client");
+    builder.put(PREFIX + '.' + BasicConfig.CLIENT_SECRET, "test-secret");
+
+    assertionConfig.forEach(
+        (k, v) ->
+            builder.put(JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION + '.' + k, v));
+
+    if (assertion != null) {
+      builder.put(JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION, assertion);
+    }
+    if (assertionFile != null) {
+      builder.put(
+          JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION_FILE, assertionFile.toString());
+    }
+
+    return builder.build();
+  }
+
+  private static AssertionSupplier createSupplier(OAuth2Config config) {
+    ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+    return AssertionSupplier.create(config, OAuth2AgentRuntime.of(executor));
+  }
+}

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestConstants.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestConstants.java
@@ -18,17 +18,23 @@ package com.dremio.iceberg.authmgr.oauth2.test;
 import static com.dremio.iceberg.authmgr.oauth2.OAuth2Config.PREFIX;
 
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.TokenTypeURI;
-import com.nimbusds.oauth2.sdk.token.TypelessAccessToken;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.catalog.SessionCatalog;
@@ -81,8 +87,18 @@ public class TestConstants {
   public static final Duration REFRESH_TOKEN_LIFESPAN =
       Duration.ofSeconds(REFRESH_TOKEN_EXPIRES_IN_SECONDS);
 
-  public static final TypelessAccessToken SUBJECT_TOKEN = new TypelessAccessToken("subject");
-  public static final TypelessAccessToken ACTOR_TOKEN = new TypelessAccessToken("actor");
+  // tokens used as configuration inputs for token exchange and jwt-bearer
+  public static final String SUBJECT_TOKEN = jwt();
+  public static final String ACTOR_TOKEN = jwt();
+  public static final String ASSERTION_TOKEN = jwt();
+
+  // access tokens returned by token endpoint expectations
+  public static final String ACCESS_TOKEN_INITIAL = jwt();
+  public static final String ACCESS_TOKEN_REFRESHED = jwt();
+
+  // refresh tokens returned by token endpoint expectations (opaque tokens)
+  public static final String REFRESH_TOKEN_INITIAL = "refresh_initial";
+  public static final String REFRESH_TOKEN_REFRESHED = "refresh_refreshed";
 
   public static final Audience AUDIENCE = new Audience("audience");
   public static final URI RESOURCE = URI.create("urn:authmgr:test:resource");
@@ -106,4 +122,23 @@ public class TestConstants {
           Map.of(PREFIX + '.' + BasicConfig.SCOPE, TestConstants.SCOPE2.toString()));
 
   private TestConstants() {}
+
+  private static String jwt() {
+    try {
+      SignedJWT jwt =
+          new SignedJWT(
+              new JWSHeader(JWSAlgorithm.HS256),
+              new JWTClaimsSet.Builder()
+                  .subject("Alice")
+                  .jwtID(UUID.randomUUID().toString())
+                  .issueTime(Date.from(NOW))
+                  .expirationTime(Date.from(ACCESS_TOKEN_EXPIRATION_TIME))
+                  .build());
+      jwt.sign(
+          new MACSigner("very-very-long-test-signing-secret".getBytes(StandardCharsets.UTF_8)));
+      return jwt.serialize();
+    } catch (JOSEException e) {
+      throw new RuntimeException("Failed to create test JWT", e);
+    }
+  }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -25,10 +25,11 @@ import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2Agent;
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
 import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
-import com.dremio.iceberg.authmgr.oauth2.config.ClientAssertionConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.HttpConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ResourceOwnerConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.SystemConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.TokenExchangeConfig;
@@ -41,6 +42,7 @@ import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableClientCredent
 import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableConfigEndpointExpectation;
 import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableDeviceCodeExpectation;
 import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableErrorExpectation;
+import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableJwtBearerExpectation;
 import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableLoadTableEndpointExpectation;
 import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutableMetadataDiscoveryExpectation;
 import com.dremio.iceberg.authmgr.oauth2.test.expectation.ImmutablePasswordExpectation;
@@ -267,7 +269,8 @@ public abstract class TestEnvironment implements AutoCloseable {
             .putAll(getDeviceCodeConfig())
             .putAll(getTokenRefreshConfig())
             .putAll(getTokenExchangeConfig())
-            .putAll(getClientAssertionConfig())
+            .putAll(getJwtBearerGrantConfig())
+            .putAll(getJwtClientAuthConfig())
             .putAll(getSystemConfig())
             .putAll(getHttpConfig())
             .build();
@@ -464,6 +467,67 @@ public abstract class TestEnvironment implements AutoCloseable {
   }
 
   @Value.Default
+  public Map<String, String> getJwtBearerGrantConfig() {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    getAssertionConfig()
+        .forEach(
+            (k, v) ->
+                builder.put(JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION + '.' + k, v));
+    if (getAssertion() != null) {
+      builder.put(JwtBearerConfig.PREFIX + '.' + JwtBearerConfig.ASSERTION, getAssertion());
+    }
+    return builder.build();
+  }
+
+  @Value.Default
+  @Nullable
+  public String getAssertion() {
+    return TestConstants.ASSERTION_TOKEN;
+  }
+
+  @Value.Default
+  public GrantType getAssertionGrantType() {
+    return GrantType.CLIENT_CREDENTIALS;
+  }
+
+  @Value.Default
+  public ClientID getAssertionClientId() {
+    return TestConstants.CLIENT_ID2;
+  }
+
+  @Value.Default
+  public Secret getAssertionClientSecret() {
+    return TestConstants.CLIENT_SECRET2;
+  }
+
+  @Value.Default
+  public Scope getAssertionScope() {
+    return TestConstants.SCOPE2;
+  }
+
+  @Value.Default
+  public Map<String, String> getAssertionConfig() {
+    ImmutableMap.Builder<String, String> builder =
+        ImmutableMap.<String, String>builder()
+            .putAll(extractPrefixMap(getBasicConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getResourceOwnerConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getAuthorizationCodeConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getDeviceCodeConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getTokenRefreshConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getJwtClientAuthConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getSystemConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getHttpConfig(), PREFIX + '.'))
+            .put(BasicConfig.GRANT_TYPE, getAssertionGrantType().getValue())
+            .put(BasicConfig.CLIENT_ID, getAssertionClientId().getValue())
+            .put(BasicConfig.EXTRA_PARAMS + ".extra2", "value2")
+            .put(BasicConfig.SCOPE, getAssertionScope().toString());
+    if (ConfigUtils.requiresClientSecret(getClientAuthenticationMethod())) {
+      builder.put(BasicConfig.CLIENT_SECRET, getAssertionClientSecret().getValue());
+    }
+    return builder.buildKeepingLast();
+  }
+
+  @Value.Default
   public Map<String, String> getTokenExchangeConfig() {
     ImmutableMap.Builder<String, String> builder =
         ImmutableMap.<String, String>builder()
@@ -514,7 +578,7 @@ public abstract class TestEnvironment implements AutoCloseable {
   @Value.Default
   @Nullable
   public Token getSubjectToken() {
-    return TestConstants.SUBJECT_TOKEN;
+    return new TypelessAccessToken(TestConstants.SUBJECT_TOKEN);
   }
 
   @Value.Default
@@ -551,7 +615,7 @@ public abstract class TestEnvironment implements AutoCloseable {
             .putAll(extractPrefixMap(getAuthorizationCodeConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getDeviceCodeConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getTokenRefreshConfig(), PREFIX + '.'))
-            .putAll(extractPrefixMap(getClientAssertionConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getJwtClientAuthConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getSystemConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getHttpConfig(), PREFIX + '.'))
             .put(BasicConfig.GRANT_TYPE, getSubjectGrantType().getValue())
@@ -567,7 +631,7 @@ public abstract class TestEnvironment implements AutoCloseable {
   @Value.Default
   @Nullable
   public Token getActorToken() {
-    return TestConstants.ACTOR_TOKEN;
+    return new TypelessAccessToken(TestConstants.ACTOR_TOKEN);
   }
 
   @Value.Default
@@ -604,7 +668,7 @@ public abstract class TestEnvironment implements AutoCloseable {
             .putAll(extractPrefixMap(getAuthorizationCodeConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getDeviceCodeConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getTokenRefreshConfig(), PREFIX + '.'))
-            .putAll(extractPrefixMap(getClientAssertionConfig(), PREFIX + '.'))
+            .putAll(extractPrefixMap(getJwtClientAuthConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getSystemConfig(), PREFIX + '.'))
             .putAll(extractPrefixMap(getHttpConfig(), PREFIX + '.'))
             .put(BasicConfig.GRANT_TYPE, getActorGrantType().getValue())
@@ -635,19 +699,18 @@ public abstract class TestEnvironment implements AutoCloseable {
   }
 
   @Value.Default
-  public Map<String, String> getClientAssertionConfig() {
+  public Map<String, String> getJwtClientAuthConfig() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     getJwsAlgorithm()
         .ifPresent(
             v ->
                 builder.put(
-                    ClientAssertionConfig.PREFIX + '.' + ClientAssertionConfig.ALGORITHM,
-                    v.getName()));
+                    JwtClientAuthConfig.PREFIX + '.' + JwtClientAuthConfig.ALGORITHM, v.getName()));
     getPrivateKey()
         .ifPresent(
             v ->
                 builder.put(
-                    ClientAssertionConfig.PREFIX + '.' + ClientAssertionConfig.PRIVATE_KEY,
+                    JwtClientAuthConfig.PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY,
                     v.toString()));
     return builder.build();
   }
@@ -748,12 +811,13 @@ public abstract class TestEnvironment implements AutoCloseable {
     if (isForceInactiveUser()) {
       return UserEmulator.INACTIVE;
     } else {
-      GrantType mainGrant = getGrantType();
-      GrantType subjectGrant = getSubjectGrantType();
-      GrantType actorGrant = getActorGrantType();
-      if (ConfigUtils.requiresUserInteraction(mainGrant)
-          || ConfigUtils.requiresUserInteraction(subjectGrant)
-          || ConfigUtils.requiresUserInteraction(actorGrant)) {
+      if (ConfigUtils.requiresUserInteraction(getGrantType())
+          || (getSubjectToken() == null
+              && ConfigUtils.requiresUserInteraction(getSubjectGrantType()))
+          || (getActorToken() == null //
+              && ConfigUtils.requiresUserInteraction(getActorGrantType()))
+          || (getAssertion() == null
+              && ConfigUtils.requiresUserInteraction(getAssertionGrantType()))) {
         return new InteractiveUserEmulator(getUserBehavior(), getUserSslContext());
       }
     }
@@ -869,8 +933,17 @@ public abstract class TestEnvironment implements AutoCloseable {
       ImmutableDeviceCodeExpectation.of(this).create();
     } else if (grantType.equals(GrantType.TOKEN_EXCHANGE)) {
       ImmutableTokenExchangeExpectation.of(this).create();
-      createInitialGrantExpectations(getSubjectGrantType());
-      createInitialGrantExpectations(getActorGrantType());
+      if (getSubjectToken() == null) {
+        createInitialGrantExpectations(getSubjectGrantType());
+      }
+      if (getActorToken() == null) {
+        createInitialGrantExpectations(getActorGrantType());
+      }
+    } else if (grantType.equals(GrantType.JWT_BEARER)) {
+      ImmutableJwtBearerExpectation.of(this).create();
+      if (getAssertion() == null) {
+        createInitialGrantExpectations(getAssertionGrantType());
+      }
     }
   }
 

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TokenAssertions.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TokenAssertions.java
@@ -27,27 +27,28 @@ public final class TokenAssertions {
   private TokenAssertions() {}
 
   public static void assertTokensResult(
-      TokensResult result, String accessToken, @Nullable String refreshToken) {
-    assertTokensResult(result, accessToken, refreshToken, refreshToken != null);
+      TokensResult actual, String expectedAccessToken, @Nullable String expectedRefreshToken) {
+    assertTokensResult(
+        actual, expectedAccessToken, expectedRefreshToken, expectedRefreshToken != null);
   }
 
   public static void assertTokensResult(
-      TokensResult result,
-      String accessToken,
-      @Nullable String refreshToken,
-      boolean expectRefreshTokenExp) {
+      TokensResult actual,
+      String expectedAccessToken,
+      @Nullable String expectedRefreshToken,
+      boolean expectRefreshTokenLifespan) {
     assertAccessToken(
-        result.getTokens().getAccessToken(),
-        accessToken,
+        actual.getTokens().getAccessToken(),
+        expectedAccessToken,
         TestConstants.ACCESS_TOKEN_EXPIRES_IN_SECONDS);
-    assertRefreshToken(result.getTokens().getRefreshToken(), refreshToken);
-    assertThat(result.getAccessTokenExpirationTime())
+    assertRefreshToken(actual.getTokens().getRefreshToken(), expectedRefreshToken);
+    assertThat(actual.getAccessTokenExpirationTime())
         .isEqualTo(TestConstants.ACCESS_TOKEN_EXPIRATION_TIME);
-    if (expectRefreshTokenExp) {
-      assertThat(result.getRefreshTokenExpirationTime())
+    if (expectRefreshTokenLifespan) {
+      assertThat(actual.getRefreshTokenExpirationTime())
           .isEqualTo(TestConstants.REFRESH_TOKEN_EXPIRATION_TIME);
     } else {
-      assertThat(result.getRefreshTokenExpirationTime()).isNull();
+      assertThat(actual.getRefreshTokenExpirationTime()).isNull();
     }
   }
 
@@ -56,7 +57,7 @@ public final class TokenAssertions {
     assertThat(actual.getLifetime()).isEqualTo(expiresInSeconds);
   }
 
-  public static void assertRefreshToken(RefreshToken actual, String expected) {
+  public static void assertRefreshToken(RefreshToken actual, @Nullable String expected) {
     if (expected == null) {
       assertThat(actual).isNull();
     } else {

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/ConfigEndpointExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/ConfigEndpointExpectation.java
@@ -17,11 +17,13 @@ package com.dremio.iceberg.authmgr.oauth2.test.expectation;
 
 import static com.dremio.iceberg.authmgr.oauth2.test.expectation.ExpectationUtils.getJsonBody;
 
+import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.TestServer;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.ResourcePaths;
 import org.apache.iceberg.rest.responses.ConfigResponse;
@@ -68,7 +70,8 @@ public abstract class ConfigEndpointExpectation extends AbstractExpectation {
                 .withMethod("GET")
                 .withPath(getTestEnvironment().getConfigEndpoint().getPath())
                 .withHeader("Accept", "application/json")
-                .withHeader("Authorization", "Bearer access_initial"))
+                .withHeader(
+                    "Authorization", "Bearer " + Pattern.quote(TestConstants.ACCESS_TOKEN_INITIAL)))
         .respond(HttpResponse.response().withBody(getJsonBody(response)));
   }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/InitialTokenFetchExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/InitialTokenFetchExpectation.java
@@ -15,6 +15,9 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.test.expectation;
 
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
+
 import com.dremio.iceberg.authmgr.oauth2.test.TestServer;
 
 public abstract class InitialTokenFetchExpectation extends AbstractTokenEndpointExpectation {
@@ -23,6 +26,6 @@ public abstract class InitialTokenFetchExpectation extends AbstractTokenEndpoint
   public void create() {
     TestServer.getInstance()
         .when(request())
-        .respond(httpRequest -> response(httpRequest, "access_initial", "refresh_initial"));
+        .respond(httpRequest -> response(httpRequest, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL));
   }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/JwtBearerExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/JwtBearerExpectation.java
@@ -15,39 +15,24 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.test.expectation;
 
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_REFRESHED;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_REFRESHED;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.SCOPE1;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.SCOPE2;
-
 import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
-import com.dremio.iceberg.authmgr.oauth2.test.TestServer;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.GrantType;
 import java.util.regex.Pattern;
 
 @AuthManagerImmutable
-public abstract class RefreshTokenExpectation extends AbstractTokenEndpointExpectation {
-
-  @Override
-  public void create() {
-    TestServer.getInstance()
-        .when(request())
-        .respond(
-            httpRequest -> response(httpRequest, ACCESS_TOKEN_REFRESHED, REFRESH_TOKEN_REFRESHED));
-  }
+public abstract class JwtBearerExpectation extends InitialTokenFetchExpectation {
 
   @Override
   protected ImmutableMap.Builder<String, String> requestBody() {
     return super.requestBody()
-        .put("grant_type", GrantType.REFRESH_TOKEN.toString())
+        .put("grant_type", GrantType.JWT_BEARER.toString())
         .put(
-            "refresh_token",
+            "assertion",
             String.format(
                 "(%s|%s)",
-                Pattern.quote(TestConstants.REFRESH_TOKEN_INITIAL),
-                Pattern.quote(TestConstants.REFRESH_TOKEN_REFRESHED)))
-        .put("scope", String.format("(%s|%s)", SCOPE1, SCOPE2));
+                Pattern.quote(TestConstants.ASSERTION_TOKEN),
+                Pattern.quote(TestConstants.ACCESS_TOKEN_INITIAL)));
   }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/LoadTableEndpointExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/LoadTableEndpointExpectation.java
@@ -17,9 +17,11 @@ package com.dremio.iceberg.authmgr.oauth2.test.expectation;
 
 import static com.dremio.iceberg.authmgr.oauth2.test.expectation.ExpectationUtils.getJsonBody;
 
+import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.TestServer;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
@@ -57,7 +59,8 @@ public abstract class LoadTableEndpointExpectation extends AbstractExpectation {
                 .withPath(getTestEnvironment().getLoadTableEndpoint().getPath())
                 .withHeader("Content-Type", "application/json")
                 .withHeader("Accept", "application/json")
-                .withHeader("Authorization", "Bearer access_initial2?"))
+                .withHeader(
+                    "Authorization", "Bearer " + Pattern.quote(TestConstants.ACCESS_TOKEN_INITIAL)))
         .respond(HttpResponse.response().withBody(getJsonBody(response)));
   }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/TokenExchangeExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/TokenExchangeExpectation.java
@@ -15,17 +15,17 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.test.expectation;
 
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACTOR_TOKEN;
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.AUDIENCE;
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.RESOURCE;
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.SCOPE1;
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.SCOPE2;
-import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.SUBJECT_TOKEN;
 
+import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import com.google.common.collect.ImmutableMap;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.token.TokenTypeURI;
+import java.util.regex.Pattern;
 
 @AuthManagerImmutable
 public abstract class TokenExchangeExpectation extends InitialTokenFetchExpectation {
@@ -34,8 +34,18 @@ public abstract class TokenExchangeExpectation extends InitialTokenFetchExpectat
   protected ImmutableMap.Builder<String, String> requestBody() {
     return super.requestBody()
         .put("grant_type", GrantType.TOKEN_EXCHANGE.toString())
-        .put("subject_token", String.format("(%s|%s)", SUBJECT_TOKEN, "access_.*"))
-        .put("actor_token", String.format("(%s|%s)", ACTOR_TOKEN, "access_.*"))
+        .put(
+            "subject_token",
+            String.format(
+                "(%s|%s)",
+                Pattern.quote(TestConstants.SUBJECT_TOKEN),
+                Pattern.quote(TestConstants.ACCESS_TOKEN_INITIAL)))
+        .put(
+            "actor_token",
+            String.format(
+                "(%s|%s)",
+                Pattern.quote(TestConstants.ACTOR_TOKEN),
+                Pattern.quote(TestConstants.ACCESS_TOKEN_INITIAL)))
         .put("subject_token_type", "urn:ietf:params:oauth:token-type:.*")
         .put("actor_token_type", "urn:ietf:params:oauth:token-type:.*")
         .put("requested_token_type", TokenTypeURI.ACCESS_TOKEN.toString())

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/junit/KeycloakExtension.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/junit/KeycloakExtension.java
@@ -25,8 +25,27 @@ import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironmentExtension;
 import com.dremio.iceberg.authmgr.oauth2.test.container.KeycloakContainer;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -63,6 +82,14 @@ public class KeycloakExtension extends TestEnvironmentExtension
 
   public static final String SCOPE1 = TestConstants.SCOPE1.toString();
 
+  public static final String JWT_BEARER_IDENTITY_PROVIDER_ALIAS = "jwt-bearer";
+  public static final String JWT_BEARER_ASSERTION_ISSUER = "https://jwt-idp.example.com";
+  public static final String JWT_BEARER_ASSERTION_SUBJECT = "alice-external";
+  public static final String JWT_BEARER_ASSERTION_PRIVATE_KEY_RESOURCE =
+      "/openssl/rsa_private_key_pkcs8.pem";
+  public static final String JWT_BEARER_ASSERTION_CERTIFICATE_RESOURCE =
+      "/openssl/rsa_certificate.pem";
+
   public static final Duration ACCESS_TOKEN_LIFESPAN = Duration.ofSeconds(15);
   public static final Duration REFRESH_TOKEN_LIFESPAN = Duration.ofSeconds(20);
 
@@ -74,6 +101,15 @@ public class KeycloakExtension extends TestEnvironmentExtension
             .withAccessTokenLifespan(ACCESS_TOKEN_LIFESPAN)
             .withRefreshTokenLifespan(REFRESH_TOKEN_LIFESPAN)
             .withUser(USERNAME, PASSWORD)
+            .withIdentityProvider(
+                JWT_BEARER_IDENTITY_PROVIDER_ALIAS,
+                JWT_BEARER_ASSERTION_ISSUER,
+                JWT_BEARER_ASSERTION_CERTIFICATE_RESOURCE)
+            .withFederatedIdentity(
+                USERNAME,
+                JWT_BEARER_IDENTITY_PROVIDER_ALIAS,
+                JWT_BEARER_ASSERTION_SUBJECT,
+                USERNAME)
             .withClient(CLIENT_ID1, CLIENT_SECRET1, CLIENT_AUTH1)
             .withClient(CLIENT_ID2, null, CLIENT_AUTH2)
             .withClient(CLIENT_ID3, CLIENT_SECRET3, CLIENT_AUTH3)
@@ -102,6 +138,7 @@ public class KeycloakExtension extends TestEnvironmentExtension
         context
             .getStore(ExtensionContext.Namespace.GLOBAL)
             .get(KeycloakContainer.class.getName(), KeycloakContainer.class);
+    Preconditions.checkNotNull(keycloak, "Keycloak container not found in extension context");
     return TestEnvironment.builder()
         .unitTest(false)
         .serverRootUrl(keycloak.getRootUrl())
@@ -118,8 +155,49 @@ public class KeycloakExtension extends TestEnvironmentExtension
         .actorClientId(TestConstants.CLIENT_ID1)
         .actorClientSecret(TestConstants.CLIENT_SECRET1)
         .actorScope(TestConstants.SCOPE1)
+        .assertion(createJwtBearerAssertion(keycloak))
         // Unused
         .audience(null)
         .resource(null);
+  }
+
+  private static String createJwtBearerAssertion(KeycloakContainer keycloak) {
+    try {
+      Instant now = Instant.now();
+      JWTClaimsSet claims =
+          new JWTClaimsSet.Builder()
+              .jwtID(UUID.randomUUID().toString())
+              .issuer(JWT_BEARER_ASSERTION_ISSUER)
+              .subject(JWT_BEARER_ASSERTION_SUBJECT)
+              .audience(keycloak.getIssuerClaim())
+              .issueTime(Date.from(now))
+              .expirationTime(Date.from(now.plusSeconds(120)))
+              .claim("preferred_username", USERNAME)
+              .build();
+      SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).build(), claims);
+      jwt.sign(new RSASSASigner(loadJwtBearerAssertionPrivateKey()));
+      return jwt.serialize();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create JWT bearer assertion for Keycloak tests", e);
+    }
+  }
+
+  private static PrivateKey loadJwtBearerAssertionPrivateKey() {
+    try (InputStream is =
+            Objects.requireNonNull(
+                KeycloakExtension.class.getResourceAsStream(
+                    JWT_BEARER_ASSERTION_PRIVATE_KEY_RESOURCE));
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+      String encoded =
+          reader.lines().filter(line -> !line.startsWith("-----")).collect(Collectors.joining());
+      byte[] decoded = Base64.getDecoder().decode(encoded);
+      return KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(decoded));
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to load JWT bearer assertion private key resource "
+              + JWT_BEARER_ASSERTION_PRIVATE_KEY_RESOURCE,
+          e);
+    }
   }
 }

--- a/oauth2/tests/src/main/java/com/dremio/iceberg/authmgr/oauth2/test/container/KeycloakContainer.java
+++ b/oauth2/tests/src/main/java/com/dremio/iceberg/authmgr/oauth2/test/container/KeycloakContainer.java
@@ -26,9 +26,14 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -40,6 +45,8 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.FederatedIdentityRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -55,8 +62,14 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
 
   private static final String CONTEXT_PATH = "/realms/master/";
 
+  protected record FederatedIdentity(
+      String username, String providerAlias, String externalUserId, String externalUsername) {}
+
   private final List<ClientScopeRepresentation> scopes = new ArrayList<>();
   private final List<ClientRepresentation> clients = new ArrayList<>();
+  private final List<IdentityProviderRepresentation> identityProviders = new ArrayList<>();
+  private final List<FederatedIdentity> federatedIdentities = new ArrayList<>();
+  private final List<String> providerAliases = new ArrayList<>();
   private final List<UserRepresentation> users = new ArrayList<>();
 
   private Duration accessTokenLifespan = Duration.ofMinutes(10);
@@ -101,6 +114,23 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
   }
 
   @CanIgnoreReturnValue
+  public KeycloakContainer withIdentityProvider(
+      String alias, String issuer, String verifyingCertificateResource) {
+    identityProviders.add(
+        newIdentityProvider(alias, issuer, loadPublicKey(verifyingCertificateResource)));
+    providerAliases.add(alias);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public KeycloakContainer withFederatedIdentity(
+      String username, String providerAlias, String externalUserId, String externalUsername) {
+    federatedIdentities.add(
+        new FederatedIdentity(username, providerAlias, externalUserId, externalUsername));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
   public KeycloakContainer withAccessTokenLifespan(Duration accessTokenLifespan) {
     this.accessTokenLifespan = accessTokenLifespan;
     return this;
@@ -127,8 +157,11 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
       RealmResource master = client.realms().realm("master");
       updateMasterRealm(master);
       scopes.forEach(scope -> createScope(master, scope));
+      identityProviders.forEach(
+          identityProvider -> createIdentityProvider(master, identityProvider));
       users.forEach(user -> createUser(master, user));
       clients.forEach(cl -> createClient(master, cl));
+      federatedIdentities.forEach(link -> createFederatedIdentityLink(master, link));
     }
   }
 
@@ -199,6 +232,16 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
   }
 
   protected void createClient(RealmResource master, ClientRepresentation client) {
+    if (!client.isPublicClient() && !providerAliases.isEmpty()) {
+      Map<String, String> attributes =
+          client.getAttributes() == null ? new HashMap<>() : new HashMap<>(client.getAttributes());
+      attributes.put("oauth2.jwt.authorization.grant.enabled", "true");
+      String keycloakMultiValueDelimiter = "##";
+      attributes.put(
+          "oauth2.jwt.authorization.grant.idp",
+          String.join(keycloakMultiValueDelimiter, providerAliases));
+      client.setAttributes(attributes);
+    }
     client.setOptionalClientScopes(
         scopes.stream().map(ClientScopeRepresentation::getName).collect(Collectors.toList()));
     try (Response response = master.clients().create(client)) {
@@ -212,11 +255,43 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
     addPrincipalRoleClaimMapper(master, client.getId());
   }
 
+  protected void createIdentityProvider(
+      RealmResource master, IdentityProviderRepresentation identityProvider) {
+    try (Response response = master.identityProviders().create(identityProvider)) {
+      if (response.getStatus() != 201) {
+        throw new IllegalStateException(
+            "Failed to create identity provider: " + response.readEntity(String.class));
+      }
+    }
+  }
+
   protected void createUser(RealmResource master, UserRepresentation user) {
     try (Response response = master.users().create(user)) {
       if (response.getStatus() != 201) {
         throw new IllegalStateException(
             "Failed to create user: " + response.readEntity(String.class));
+      }
+    }
+  }
+
+  protected void createFederatedIdentityLink(RealmResource master, FederatedIdentity link) {
+    String userId =
+        master.users().searchByUsername(link.username(), true).stream()
+            .findFirst()
+            .map(UserRepresentation::getId)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Failed to find user for federated identity link: " + link.username()));
+    FederatedIdentityRepresentation rep = new FederatedIdentityRepresentation();
+    rep.setIdentityProvider(link.providerAlias());
+    rep.setUserId(link.externalUserId());
+    rep.setUserName(link.externalUsername());
+    try (Response response =
+        master.users().get(userId).addFederatedIdentity(link.providerAlias(), rep)) {
+      if (response.getStatus() != 204) {
+        throw new IllegalStateException(
+            "Failed to create federated identity link: " + response.readEntity(String.class));
       }
     }
   }
@@ -277,6 +352,26 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
     }
     client.setAttributes(attributes.build());
     return client;
+  }
+
+  private static IdentityProviderRepresentation newIdentityProvider(
+      String alias, String issuer, String publicKeyPem) {
+    IdentityProviderRepresentation identityProvider = new IdentityProviderRepresentation();
+    identityProvider.setAlias(alias);
+    identityProvider.setProviderId("jwt-authorization-grant");
+    identityProvider.setDisplayName(alias);
+    identityProvider.setEnabled(true);
+    identityProvider.setHideOnLogin(true);
+    identityProvider.setConfig(
+        ImmutableMap.<String, String>builder()
+            .put("issuer", issuer)
+            .put("useJwksUrl", "false")
+            .put("jwtAuthorizationGrantEnabled", "true")
+            .put("jwtAuthorizationGrantAssertionReuseAllowed", "true")
+            .put("jwtAuthorizationGrantAllowedClockSkew", "30")
+            .put("publicKeySignatureVerifier", publicKeyPem)
+            .build());
+    return identityProvider;
   }
 
   private static UserRepresentation newUser(String username, String password) {
@@ -359,6 +454,19 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
           .filter(line -> !line.startsWith("-----"))
           .collect(Collectors.joining(""));
     } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String loadPublicKey(String certificateResource) {
+    try (InputStream is =
+        Objects.requireNonNull(KeycloakContainer.class.getResourceAsStream(certificateResource))) {
+      Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(is);
+      String encoded =
+          Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8))
+              .encodeToString(certificate.getPublicKey().getEncoded());
+      return "-----BEGIN PUBLIC KEY-----\n" + encoded + "\n-----END PUBLIC KEY-----";
+    } catch (IOException | CertificateException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Fixes #208.

This change introduces support for JWT Bearer grants (RFC 7523).

The Auth Manager already has support fur JWT client auth, also introduced by RFC 7523.

In order to clarify the configuration, the client auth part of RFC 7523 has been relocated from `rest.auth.oauth2.client-assertion.jwt.*` to `rest.auth.oauth2.client-auth.jwt.*`.