### PR TITLE
fix(crypto): Fix BC and JCA private key reading

### DIFF
--- a/docs/client-authentication.md
+++ b/docs/client-authentication.md
@@ -112,12 +112,12 @@ in the file is used.
 
 The following format is always supported:
 
-1. RSA keys in PKCS#8 format (`BEGIN PRIVATE KEY`)
+1. RSA or EC (Elliptic Curve) keys in PKCS#8 format (`BEGIN PRIVATE KEY`)
 
 If the BouncyCastle library is available at runtime, the following formats are also supported:
 
 2. RSA keys in PKCS#1 format (`BEGIN RSA PRIVATE KEY`)
-3. EC (Elliptic Curve) keys (`BEGIN EC PRIVATE KEY`)
+3. EC (Elliptic Curve) keys in EC SEC 1 format (`BEGIN EC PRIVATE KEY`)
 
 Only unencrypted private keys are supported.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -462,9 +462,9 @@ The file must be in PEM format; it may contain a private key, or a private key a
 
 Supported key formats are:
 
-- RSA PKCS#8 (`BEGIN PRIVATE KEY`): always supported
-- RSA PKCS#1 (`BEGIN RSA PRIVATE KEY`): requires the BouncyCastle library
-- ECDSA (`BEGIN EC PRIVATE KEY`): requires the BouncyCastle library
+- RSA & ECDSA in PKCS#8 format (`BEGIN PRIVATE KEY`): always supported
+- RSA in PKCS#1 format (`BEGIN RSA PRIVATE KEY`): requires the BouncyCastle library
+- ECDSA in EC SEC 1 format (`BEGIN EC PRIVATE KEY`): requires the BouncyCastle library
 
 Only unencrypted keys are supported currently.
 

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
@@ -170,11 +170,14 @@ public class OAuth2AgentKeycloakIT {
   void privateKeyJwt(
       @EnumLike(excludes = "urn:ietf:params:oauth:grant-type:token-exchange")
           GrantType initialGrantType,
-      @Values(strings = {"rsa_pkcs8", "rsa_pkcs1", "ecdsa_sec1"}) String keyType,
+      @Values(strings = {"rsa_pkcs8", "rsa_pkcs1", "ecdsa_pkcs8", "ecdsa_sec1"}) String keyType,
       Builder envBuilder)
       throws Exception {
     TestCertificates certs = TestCertificates.instance();
-    assumeThat(certs.isBouncyCastleAvailable() || keyType.equals("rsa_pkcs8"))
+    assumeThat(
+            certs.isBouncyCastleAvailable()
+                || keyType.equals("rsa_pkcs8")
+                || keyType.equals("ecdsa_pkcs8"))
         .as("BouncyCastle is required for RSA PKCS#1 and ECDSA SEC 1 keys")
         .isTrue();
     Path privateKeyPath;
@@ -190,6 +193,11 @@ public class OAuth2AgentKeycloakIT {
         privateKeyPath = certs.getRsaPrivateKeyPkcs1Pem();
         algorithm = JWSAlgorithm.RS256;
         clientId = CLIENT_ID4;
+        break;
+      case "ecdsa_pkcs8":
+        privateKeyPath = certs.getEcdsaPrivateKeyPkcs8Pem();
+        algorithm = JWSAlgorithm.ES256;
+        clientId = CLIENT_ID5;
         break;
       case "ecdsa_sec1":
         privateKeyPath = certs.getEcdsaPrivateKeySec1Pem();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfig.java
@@ -116,9 +116,10 @@ public interface JwtClientAuthConfig {
    * <p>Supported key formats are:
    *
    * <ul>
-   *   <li>RSA PKCS#8 ({@code BEGIN PRIVATE KEY}): always supported
-   *   <li>RSA PKCS#1 ({@code BEGIN RSA PRIVATE KEY}): requires the BouncyCastle library
-   *   <li>ECDSA ({@code BEGIN EC PRIVATE KEY}): requires the BouncyCastle library
+   *   <li>RSA & ECDSA in PKCS#8 format ({@code BEGIN PRIVATE KEY}): always supported
+   *   <li>RSA in PKCS#1 format ({@code BEGIN RSA PRIVATE KEY}): requires the BouncyCastle library
+   *   <li>ECDSA in EC SEC 1 format ({@code BEGIN EC PRIVATE KEY}): requires the BouncyCastle
+   *       library
    * </ul>
    *
    * Only unencrypted keys are supported currently.

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReader.java
@@ -42,9 +42,9 @@ final class BouncyCastlePemReader implements PemReader {
    * Reads a private key from a PEM file. Supported key formats:
    *
    * <ul>
+   *   <li>RSA or EC PKCS#8 (BEGIN PRIVATE KEY)
    *   <li>RSA PKCS#1 (BEGIN RSA PRIVATE KEY)
-   *   <li>RSA PKCS#8 (BEGIN PRIVATE KEY)
-   *   <li>EC (BEGIN EC PRIVATE KEY)
+   *   <li>EC SEC 1 (BEGIN EC PRIVATE KEY)
    * </ul>
    *
    * <p>Only unencrypted keys are supported.
@@ -72,16 +72,16 @@ final class BouncyCastlePemReader implements PemReader {
   }
 
   private static PrivateKey extractPrivateKey(Object pemObject) throws PEMException {
+    // Nimbus JOSE JWT uses "EC" as the algorithm name for EC keys,
+    // but BouncyCastle uses "ECDSA"; normalize to "EC" for compatibility.
+    JcaPEMKeyConverter converter =
+        new JcaPEMKeyConverter().setAlgorithmMapping(X9ObjectIdentifiers.id_ecPublicKey, "EC");
     if (pemObject instanceof PEMKeyPair) {
-      // Handle PKCS#1 format (BEGIN RSA PRIVATE KEY) or EC (BEGIN EC PRIVATE KEY)
-      return new JcaPEMKeyConverter()
-          // Nimbus JOSE JWT uses "EC" as the algorithm name for EC keys,
-          // but BouncyCastle uses "ECDSA"
-          .setAlgorithmMapping(X9ObjectIdentifiers.id_ecPublicKey, "EC")
-          .getPrivateKey(((PEMKeyPair) pemObject).getPrivateKeyInfo());
+      // Handle PKCS#1 format (BEGIN RSA PRIVATE KEY) or SEC 1 (BEGIN EC PRIVATE KEY)
+      return converter.getPrivateKey(((PEMKeyPair) pemObject).getPrivateKeyInfo());
     } else if (pemObject instanceof PrivateKeyInfo) {
       // Handle PKCS#8 format (BEGIN PRIVATE KEY)
-      return new JcaPEMKeyConverter().getPrivateKey((PrivateKeyInfo) pemObject);
+      return converter.getPrivateKey((PrivateKeyInfo) pemObject);
     }
     return null;
   }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReader.java
@@ -21,18 +21,32 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
 final class JcaPemReader implements PemReader {
 
+  private static final String[] ALGORITHMS = {"RSA", "EC"};
+
   @Override
   public PrivateKey readPrivateKey(Path file) {
     try {
       byte[] encoded = Base64.decodeBase64(readPemEncodedPrivateKey(file));
-      KeyFactory keyFactory = KeyFactory.getInstance("RSA");
       PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
-      return keyFactory.generatePrivate(keySpec);
+      InvalidKeySpecException toThrow = null;
+      for (String algorithm : ALGORITHMS) {
+        try {
+          return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+        } catch (InvalidKeySpecException e) {
+          if (toThrow == null) {
+            toThrow = e;
+          } else {
+            toThrow.addSuppressed(e);
+          }
+        }
+      }
+      throw toThrow;
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to read PEM file: " + file, e);
     }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/PemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/PemReader.java
@@ -28,10 +28,10 @@ public interface PemReader {
   /**
    * Reads a private key from a PEM file.
    *
-   * <p>RSA keys in the PKCS#8 format are always supported.
+   * <p>RSA and ECDSA keys in the PKCS#8 format are always supported.
    *
-   * <p>Support for additional key formats, such as RSA in the PKCS#1 format or ECDSA keys, is
-   * supported if the BouncyCastle library is available.
+   * <p>Support for additional key formats, such as RSA in the PKCS#1 format or ECDSA keys in SEC 1
+   * format, is supported if the BouncyCastle library is available.
    *
    * <p>Only unencrypted keys are supported.
    *

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReaderTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReaderTest.java
@@ -26,8 +26,11 @@ import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class BouncyCastlePemReaderTest {
 
@@ -64,7 +67,21 @@ class BouncyCastlePemReaderTest {
   }
 
   @Test
-  void testReadEcPrivateKey() {
+  void testReadEcPkcs8PrivateKey() {
+    // Given
+    Path privateKeyFile = TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem();
+
+    // When
+    PrivateKey privateKey = new BouncyCastlePemReader().readPrivateKey(privateKeyFile);
+
+    // Then
+    assertThat(privateKey).isNotNull();
+    assertThat(privateKey.getAlgorithm()).isEqualTo("EC");
+    assertThat(privateKey).isInstanceOf(ECPrivateKey.class);
+  }
+
+  @Test
+  void testReadEcSec1PrivateKey() {
     // Given
     Path privateKeyFile = TestCertificates.instance().getEcdsaPrivateKeySec1Pem();
 
@@ -73,7 +90,7 @@ class BouncyCastlePemReaderTest {
 
     // Then
     assertThat(privateKey).isNotNull();
-    assertThat(privateKey.getAlgorithm()).isIn("EC", "ECDSA"); // BouncyCastle may return "ECDSA"
+    assertThat(privateKey.getAlgorithm()).isEqualTo("EC");
     assertThat(privateKey).isInstanceOf(ECPrivateKey.class);
   }
 
@@ -104,17 +121,23 @@ class BouncyCastlePemReaderTest {
         .hasMessageContaining("No private key found in file");
   }
 
-  @Test
-  void testReadFileWithoutPrivateKey() {
-    // Given
-    Path privateKeyFile = TestCertificates.instance().getRsaCertificatePem();
-
+  @ParameterizedTest
+  @MethodSource("invalidPemFiles")
+  void testReadFileWithoutPrivateKey(Path certificateFile) {
     // When - Then
-    assertThatThrownBy(() -> new BouncyCastlePemReader().readPrivateKey(privateKeyFile))
+    assertThatThrownBy(() -> new BouncyCastlePemReader().readPrivateKey(certificateFile))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Failed to read PEM file")
         .rootCause()
         .hasMessageContaining("No private key found in file");
+  }
+
+  static Stream<Path> invalidPemFiles() {
+    return Stream.of(
+        TestCertificates.instance().getRsaPublicKeyPem(),
+        TestCertificates.instance().getRsaCertificatePem(),
+        TestCertificates.instance().getEcdsaPublicKeyPem(),
+        TestCertificates.instance().getEcdsaCertificatePem());
   }
 
   @Test

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReaderTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReaderTest.java
@@ -24,9 +24,13 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class JcaPemReaderTest {
 
@@ -45,6 +49,20 @@ class JcaPemReaderTest {
     assertThat(privateKey.getAlgorithm()).isEqualTo("RSA");
     assertThat(privateKey).isInstanceOf(RSAPrivateKey.class);
     assertThat(((RSAPrivateKey) privateKey).getModulus().bitLength()).isEqualTo(2048);
+  }
+
+  @Test
+  void testReadEcPkcs8PrivateKey() {
+    // Given
+    Path privateKeyFile = TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem();
+
+    // When
+    PrivateKey privateKey = new JcaPemReader().readPrivateKey(privateKeyFile);
+
+    // Then
+    assertThat(privateKey).isNotNull();
+    assertThat(privateKey.getAlgorithm()).isEqualTo("EC");
+    assertThat(privateKey).isInstanceOf(ECPrivateKey.class);
   }
 
   @Test
@@ -74,17 +92,23 @@ class JcaPemReaderTest {
         .hasMessageContaining("No private key found in file");
   }
 
-  @Test
-  void testReadFileWithoutPrivateKey() {
-    // Given
-    Path certificateFile = TestCertificates.instance().getRsaCertificatePem();
-
+  @ParameterizedTest
+  @MethodSource("invalidPemFiles")
+  void testReadFileWithoutPrivateKey(Path certificateFile) {
     // When - Then
     assertThatThrownBy(() -> new JcaPemReader().readPrivateKey(certificateFile))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Failed to read PEM file")
         .rootCause()
         .hasMessageContaining("No private key found in file");
+  }
+
+  static Stream<Path> invalidPemFiles() {
+    return Stream.of(
+        TestCertificates.instance().getRsaPublicKeyPem(),
+        TestCertificates.instance().getRsaCertificatePem(),
+        TestCertificates.instance().getEcdsaPublicKeyPem(),
+        TestCertificates.instance().getEcdsaCertificatePem());
   }
 
   @Test


### PR DESCRIPTION
This change fixes 2 issues:

- The JCA PEM reader was incorrectly hard-coding the algorithm to RSA, thus making it impossible to read an ECDSA file in PKCS#8 format.
- The BC PEM reader was not setting the key ID to "EC" when reading PKCS#8 format, causing Nimbus JOSE JWT to fail for any ECDSA key in PKCS#8 format.