### PR TITLE
fix(test): fix callback HTTP status assertion in AuthorizationCodeUserFlow

### DIFF
--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/user/AuthorizationCodeUserFlow.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/user/AuthorizationCodeUserFlow.java
@@ -16,7 +16,6 @@
 package com.dremio.iceberg.authmgr.oauth2.test.user;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
@@ -78,6 +77,6 @@ public abstract class AuthorizationCodeUserFlow extends UserFlow {
     conn.setRequestMethod("GET");
     int status = conn.getResponseCode();
     conn.disconnect();
-    assertThat(status).isEqualTo(useWrongCode ? HTTP_UNAUTHORIZED : HTTP_OK);
+    assertThat(status).isEqualTo(HTTP_OK);
   }
 }


### PR DESCRIPTION


The callback failure response was changed from HTTP 401 to HTTP 200 in commit 8e580ab, but the test harness assertion in `invokeCallbackUrl()` was not updated accordingly.

This creates a race condition where depending on whether the user emulator finishes before or after the OAuth2 agent, the test could fail.

Always expect HTTP 200 from the callback server regardless of whether the code is valid or not.