### PR TITLE
fix(config): reject unsupported JWS algorithms at validation time

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,6 +442,8 @@ The expiration time of the client assertion JWT. Optional. The default is 5 minu
 
 The signing algorithm to use for the client assertion JWT. Optional. The default is `HS512` if the authentication method is `client_secret_jwt`, or `RS512` if the authentication method is `private_key_jwt`.
 
+Supported algorithms are: HMAC-SHA for `client_secret_jwt`, and RSA or EC for `private_key_jwt`.
+
 Algorithm names must match the "alg" Param Value as described in [RFC 7518 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).
 
 ### `rest.auth.oauth2.client-auth.jwt.key-id`

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfig.java
@@ -83,6 +83,9 @@ public interface JwtClientAuthConfig {
    * ClientAuthenticationMethod#CLIENT_SECRET_JWT}, or {@link JWSAlgorithm#RS512} if the
    * authentication method is {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
    *
+   * <p>Supported algorithms are: HMAC-SHA for {@code client_secret_jwt}, and RSA or EC for {@code
+   * private_key_jwt}.
+   *
    * <p>Algorithm names must match the "alg" Param Value as described in <a
    * href="https://datatracker.ietf.org/doc/html/rfc7518#section-3.1">RFC 7518 Section 3.1</a>.
    */
@@ -133,7 +136,8 @@ public interface JwtClientAuthConfig {
   default void validate() {
     ConfigValidator validator = new ConfigValidator();
     if (getAlgorithm().isPresent()) {
-      if (JWSAlgorithm.Family.SIGNATURE.contains(getAlgorithm().get())) {
+      if (JWSAlgorithm.Family.RSA.contains(getAlgorithm().get())
+          || JWSAlgorithm.Family.EC.contains(getAlgorithm().get())) {
         validator.check(
             getPrivateKey().isPresent(),
             List.of(PREFIX + '.' + ALGORITHM, PREFIX + '.' + PRIVATE_KEY),
@@ -151,8 +155,11 @@ public interface JwtClientAuthConfig {
             PREFIX + '.' + ALGORITHM,
             "client assertion: unsupported JWS algorithm '%s', must be one of: %s",
             getAlgorithm().get().getName(),
-            Stream.concat(
-                    JWSAlgorithm.Family.HMAC_SHA.stream(), JWSAlgorithm.Family.SIGNATURE.stream())
+            Stream.of(
+                    JWSAlgorithm.Family.HMAC_SHA.stream(),
+                    JWSAlgorithm.Family.RSA.stream(),
+                    JWSAlgorithm.Family.EC.stream())
+                .flatMap(s -> s)
                 .map(JWSAlgorithm::getName)
                 .collect(Collectors.joining("', '", "'", "'")));
       }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/JwtClientAuthConfigTest.java
@@ -84,7 +84,17 @@ class JwtClientAuthConfigTest {
                 tempFile.toString()),
             List.of(
                 "client assertion: unsupported JWS algorithm 'RSA_SHA256', must be one of: "
-                    + "'HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES256K', 'ES384', 'ES512', 'EdDSA', 'Ed25519', 'Ed448' "
+                    + "'HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES256K', 'ES384', 'ES512' "
+                    + "(rest.auth.oauth2.client-auth.jwt.algorithm)")),
+        Arguments.of(
+            Map.of(
+                PREFIX + '.' + JwtClientAuthConfig.ALGORITHM,
+                "EdDSA",
+                PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY,
+                tempFile.toString()),
+            List.of(
+                "client assertion: unsupported JWS algorithm 'EdDSA', must be one of: "
+                    + "'HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES256K', 'ES384', 'ES512' "
                     + "(rest.auth.oauth2.client-auth.jwt.algorithm)")),
         Arguments.of(
             Map.of(PREFIX + '.' + JwtClientAuthConfig.PRIVATE_KEY, "/invalid/path"),


### PR DESCRIPTION
`JwtClientAuthConfig.validate()` allowed any member of `JWSAlgorithm.Family.SIGNATURE`, which includes EdDSA/Ed25519/Ed448. These are not actually supported by the pipeline (`PemReader` cannot parse Edwards-curve PEMs), so users hit a confusing runtime error at first token request instead of a clear message at startup.