### PR TITLE
feat(dpop): add DPoP (RFC 9449) support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,14 @@ to configure impersonation and delegation.
 The Dremio AuthManager for Apache Iceberg supports JWT assertion grants with static or dynamic
 assertions. See the [JWT Bearer Grant](./jwt-bearer.md) section for more details.
 
+## Sender-Constrained Access Tokens (DPoP)
+
+The Dremio AuthManager for Apache Iceberg supports
+[Demonstrating Proof of Possession (DPoP)](./dpop.md)
+([RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)), which binds access tokens to an
+asymmetric keypair held by the client so that stolen tokens cannot be replayed. DPoP is opt-in; see
+the [DPoP](./dpop.md) section for details on how to enable and configure it.
+
 ## Migration From Iceberg's Built-In OAuth2 `AuthManager`
 
 Migrating from Iceberg's built-in OAuth2 `AuthManager` to the Dremio AuthManager for Apache Iceberg

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -470,6 +470,52 @@ Only unencrypted keys are supported currently.
 
 Extra claims to include in the client assertion JWT. This is a prefix property, and multiple values can be set, each with a different key and value.
 
+## DPoP Settings
+
+Configuration properties for [RFC 9449: OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449).
+
+When enabled, the agent generates or loads an asymmetric keypair and attaches a signed DPoP proof JWT to every request sent to the authorization server's token endpoint, as well as to every authenticated request sent to the protected resource server.
+
+DPoP is disabled by default. To enable it, set `rest.auth.oauth2.dpop.enabled=true`.
+
+### `rest.auth.oauth2.dpop.enabled`
+
+Whether DPoP support is enabled. Defaults to `false`.
+
+When enabled, every request to the token endpoint and every authenticated request to the resource server will carry a `DPoP` header with a signed proof JWT, and the `Authorization` header scheme for resource-server requests will switch from `Bearer` to `DPoP`.
+
+### `rest.auth.oauth2.dpop.algorithm`
+
+The JWS algorithm to use for signing DPoP proof JWTs. Defaults to `ES256`.
+
+Per RFC 9449, the signing key MUST be asymmetric; thus only asymmetric algorithms are accepted (e.g. `ES256`, `ES384`, `ES512`, `RS256`, `PS256`, etc.). `ES256K` and the `EdDSA` family are not currently supported.
+
+Algorithm names must match the "alg" Param Value as described in [RFC 7518 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).
+
+### `rest.auth.oauth2.dpop.private-key`
+
+The path on the local filesystem to the private key to use for signing DPoP proofs. Optional.
+
+If not set, a fresh ephemeral keypair matching the configured `rest.auth.oauth2.dpop.algorithm` is generated when the agent starts and discarded on shutdown.
+
+If set, the file must be in PEM format; it may contain a private key, or a private key and a certificate chain. Only the private key is used.
+
+Supported key formats are:
+
+- RSA & ECDSA in PKCS#8 format (`BEGIN PRIVATE KEY`): always supported
+- RSA in PKCS#1 format (`BEGIN RSA PRIVATE KEY`): requires the BouncyCastle library
+- ECDSA in EC SEC 1 format (`BEGIN EC PRIVATE KEY`): requires the BouncyCastle library
+
+Only unencrypted keys are supported currently.
+
+### `rest.auth.oauth2.dpop.public-key`
+
+The path on the local filesystem to an optional public key PEM file accompanying `rest.auth.oauth2.dpop.private-key`. Optional.
+
+When set, the file must contain a `-----BEGIN PUBLIC KEY-----` block (X.509 SubjectPublicKeyInfo, as produced by `openssl pkey -pubout`) for the public counterpart of the configured private key. When not set, the public key is derived from the private key automatically; this always works for RSA keys but requires BouncyCastle on the runtime classpath for EC keys.
+
+Ignored when `rest.auth.oauth2.dpop.private-key` is not set (ephemeral mode).
+
 ## System Settings
 
 Configuration properties for the whole system.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -474,7 +474,7 @@ Extra claims to include in the client assertion JWT. This is a prefix property, 
 
 Configuration properties for [RFC 9449: OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449).
 
-When enabled, the agent generates or loads an asymmetric keypair and attaches a signed DPoP proof JWT to every request sent to the authorization server's token endpoint, as well as to every authenticated request sent to the protected resource server.
+When enabled, the agent generates an ephemeral asymmetric keypair and attaches a signed DPoP proof JWT to every request sent to the authorization server's token endpoint, as well as to every authenticated request sent to the protected resource server.
 
 DPoP is disabled by default. To enable it, set `rest.auth.oauth2.dpop.enabled=true`.
 
@@ -491,30 +491,6 @@ The JWS algorithm to use for signing DPoP proof JWTs. Defaults to `ES256`.
 Per RFC 9449, the signing key MUST be asymmetric; thus only asymmetric algorithms are accepted (e.g. `ES256`, `ES384`, `ES512`, `RS256`, `PS256`, etc.). `ES256K` and the `EdDSA` family are not currently supported.
 
 Algorithm names must match the "alg" Param Value as described in [RFC 7518 Section 3.1](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).
-
-### `rest.auth.oauth2.dpop.private-key`
-
-The path on the local filesystem to the private key to use for signing DPoP proofs. Optional.
-
-If not set, a fresh ephemeral keypair matching the configured `rest.auth.oauth2.dpop.algorithm` is generated when the agent starts and discarded on shutdown.
-
-If set, the file must be in PEM format; it may contain a private key, or a private key and a certificate chain. Only the private key is used.
-
-Supported key formats are:
-
-- RSA & ECDSA in PKCS#8 format (`BEGIN PRIVATE KEY`): always supported
-- RSA in PKCS#1 format (`BEGIN RSA PRIVATE KEY`): requires the BouncyCastle library
-- ECDSA in EC SEC 1 format (`BEGIN EC PRIVATE KEY`): requires the BouncyCastle library
-
-Only unencrypted keys are supported currently.
-
-### `rest.auth.oauth2.dpop.public-key`
-
-The path on the local filesystem to an optional public key PEM file accompanying `rest.auth.oauth2.dpop.private-key`. Optional.
-
-When set, the file must contain a `-----BEGIN PUBLIC KEY-----` block (X.509 SubjectPublicKeyInfo, as produced by `openssl pkey -pubout`) for the public counterpart of the configured private key. When not set, the public key is derived from the private key automatically; this always works for RSA keys but requires BouncyCastle on the runtime classpath for EC keys.
-
-Ignored when `rest.auth.oauth2.dpop.private-key` is not set (ephemeral mode).
 
 ## System Settings
 

--- a/docs/dpop.md
+++ b/docs/dpop.md
@@ -1,0 +1,164 @@
+<!--
+Copyright (C) 2025 Dremio Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Dremio AuthManager for Apache Iceberg - DPoP (Demonstrating Proof of Possession)
+
+## Overview
+
+The Dremio AuthManager for Apache Iceberg supports
+[RFC 9449: OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449).
+
+DPoP binds an access token to an asymmetric keypair held by the client. Every request carries a
+short-lived, signed JWT ("DPoP proof") whose public key matches the one the access token was issued
+for. Therefore, a stolen access token cannot be replayed by an attacker who does not also possess 
+the private key.
+
+When DPoP is enabled, the AuthManager:
+
+* Generates or loads an asymmetric keypair on startup.
+* Attaches a `DPoP` header carrying a signed proof JWT to every request sent to the authorization
+  server's token endpoint.
+* Requests a DPoP-bound access token from the authorization server (`token_type=DPoP` per RFC 9449
+  §5).
+* Attaches a `DPoP` header — including the required `ath` (access token hash) claim — to every
+  authenticated request sent to the resource server, and switches the `Authorization` scheme from
+  `Bearer` to `DPoP`.
+* Transparently handles the `use_dpop_nonce` challenge (RFC 9449 §8) from the authorization server
+  by capturing the server-issued nonce and retrying the request once.
+
+DPoP is disabled by default. To enable it, set `rest.auth.oauth2.dpop.enabled=true`.
+
+## Quick Start
+
+The minimal configuration is simply to turn DPoP on:
+
+```properties
+rest.auth.type=com.dremio.iceberg.authmgr.oauth2.OAuth2Manager
+
+rest.auth.oauth2.issuer-url=https://idp.example.com/realms/main
+rest.auth.oauth2.grant-type=client_credentials
+rest.auth.oauth2.client-id=my-client
+rest.auth.oauth2.client-secret=s3cret
+rest.auth.oauth2.scope=catalog
+
+rest.auth.oauth2.dpop.enabled=true
+```
+
+With this configuration the AuthManager generates a fresh `ES256` keypair when it starts, uses it
+for the lifetime of the agent, and discards it on shutdown. The authorization server must be
+configured to accept DPoP-bound tokens for this client. For example, in Keycloak 26.x this means
+enabling the `dpop` feature and setting `dpop.bound.access.tokens=true` on the client.
+
+## Key Management
+
+### Ephemeral Keys
+
+When no private key path is configured, the AuthManager generates a new keypair each time the agent
+starts. The key lives entirely in memory and never leaves the process. This is the simplest and
+recommended mode for most deployments, especially short-lived processes such as Spark jobs.
+
+A new key means a new `cnf.jkt` thumbprint on every fresh access token — any tokens issued to a
+previous agent instance are no longer refreshable once that agent shuts down, since refresh requires
+signing with the same key the original token was bound to (RFC 9449 §5). The AuthManager satisfies
+this implicitly: it reuses a single key for the lifetime of the agent.
+
+### Static Keys from a PEM File
+
+For deployments that need a stable `cnf.jkt` thumbprint across process restarts, provide a 
+PEM-encoded private key:
+
+```properties
+rest.auth.oauth2.dpop.enabled=true
+rest.auth.oauth2.dpop.algorithm=ES256
+rest.auth.oauth2.dpop.private-key=/etc/authmgr/dpop-key.pem
+```
+
+The file must be in PEM format. The following formats are always supported:
+
+1. RSA or EC (Elliptic Curve) keys in PKCS#8 format (`BEGIN PRIVATE KEY`)
+
+If the BouncyCastle library is available at runtime, the following formats are also supported:
+
+2. RSA keys in PKCS#1 format (`BEGIN RSA PRIVATE KEY`)
+3. EC (Elliptic Curve) keys in EC SEC 1 format (`BEGIN EC PRIVATE KEY`)
+
+Only unencrypted private keys are supported.
+
+By default, the public key is derived from the private key at load time; this always works for RSA
+keys but requires BouncyCastle on the classpath for EC keys. To avoid the BouncyCastle dependency,
+supply the public key explicitly via `rest.auth.oauth2.dpop.public-key`:
+
+```properties
+rest.auth.oauth2.dpop.enabled=true
+rest.auth.oauth2.dpop.algorithm=ES256
+rest.auth.oauth2.dpop.private-key=/etc/authmgr/dpop-key.pem
+rest.auth.oauth2.dpop.public-key=/etc/authmgr/dpop-key.pub.pem
+```
+
+The public-key file must contain an X.509 `SubjectPublicKeyInfo` block
+(`-----BEGIN PUBLIC KEY-----`), as produced by `openssl pkey -pubout`.
+
+## Signing Algorithms
+
+The signing algorithm is controlled by `rest.auth.oauth2.dpop.algorithm`. Per RFC 9449 the signing
+key must be asymmetric; only RSA- and EC-family algorithms are accepted. The default is `ES256`,
+which produces the smallest proofs.
+
+| Algorithm | Key Type | Notes                                            |
+|-----------|----------|--------------------------------------------------|
+| `ES256`   | EC P-256 | Default. Smallest proofs.                        |
+| `ES384`   | EC P-384 |                                                  |
+| `ES512`   | EC P-521 |                                                  |
+| `RS256`   | RSA      | Widely supported by authorization servers.       |
+| `RS384`   | RSA      |                                                  |
+| `RS512`   | RSA      |                                                  |
+| `PS256`   | RSA      | RSASSA-PSS; preferred over `RS*` when available. |
+| `PS384`   | RSA      |                                                  |
+| `PS512`   | RSA      |                                                  |
+
+`ES256K` (secp256k1) and the `EdDSA` family (Ed25519 / Ed448) are not currently supported.
+
+For an ephemeral keypair the AuthManager generates a key matching the configured algorithm. For a
+static PEM key, the key type must match the algorithm family (EC for `ES*`, RSA for `RS*`/`PS*`).
+
+## Nonce Handling
+
+RFC 9449 §8 lets the authorization server require the client to include a `nonce` claim in every
+DPoP proof, supplying the current value via a `DPoP-Nonce` response header. The AuthManager handles
+this transparently: the first request goes out without a `nonce` claim; if the server responds with
+`400 use_dpop_nonce`, the AuthManager captures the `DPoP-Nonce` header value, re-signs the proof
+with the `nonce` claim set, and retries the request once. Subsequent requests reuse the cached
+nonce (and update it whenever the server refreshes it).
+
+No configuration is needed — nonce challenges are handled automatically for the token endpoint.
+
+## Known Limitations
+
+* **Resource-server nonce challenges are not supported.** The underlying Iceberg `HTTPClient` does
+  not surface response headers or 401 bodies back to the AuthManager, so a resource-server nonce
+  challenge (RFC 9449 §9: a 401 with `WWW-Authenticate: DPoP error="use_dpop_nonce"` accompanied by
+  a `DPoP-Nonce` response header) cannot be observed and the nonce cannot be captured for the
+  retry. If a resource server mandates per-request nonces, DPoP will fail against it until the
+  Iceberg HTTPClient grows an interception hook. (Token-endpoint nonce challenges — which go through
+  the AuthManager's own HTTP client — *are* supported.)
+
+* **No key rotation.** An ephemeral key lives as long as the agent; a static key lives as long as
+  the PEM file points at it. To rotate, restart the process (for ephemeral keys) or replace the PEM
+  file and restart (for static keys).
+
+## Full Configuration Reference
+
+See the [Configuration](./configuration.md#dpop-settings) section for the full list of DPoP
+configuration properties.

--- a/docs/dpop.md
+++ b/docs/dpop.md
@@ -27,7 +27,7 @@ the private key.
 
 When DPoP is enabled, the AuthManager:
 
-* Generates or loads an asymmetric keypair on startup.
+* Generates an ephemeral asymmetric keypair on startup.
 * Attaches a `DPoP` header carrying a signed proof JWT to every request sent to the authorization
   server's token endpoint.
 * Requests a DPoP-bound access token from the authorization server (`token_type=DPoP` per RFC 9449
@@ -63,52 +63,15 @@ enabling the `dpop` feature and setting `dpop.bound.access.tokens=true` on the c
 
 ## Key Management
 
-### Ephemeral Keys
-
-When no private key path is configured, the AuthManager generates a new keypair each time the agent
-starts. The key lives entirely in memory and never leaves the process. This is the simplest and
-recommended mode for most deployments, especially short-lived processes such as Spark jobs.
+The AuthManager generates a fresh keypair each time the agent starts. The key lives entirely in
+memory and never leaves the process. This is the simplest and most secure approach: a stolen access
+token cannot be replayed without the private key, and the private key never leaves the agent's
+memory.
 
 A new key means a new `cnf.jkt` thumbprint on every fresh access token — any tokens issued to a
 previous agent instance are no longer refreshable once that agent shuts down, since refresh requires
 signing with the same key the original token was bound to (RFC 9449 §5). The AuthManager satisfies
 this implicitly: it reuses a single key for the lifetime of the agent.
-
-### Static Keys from a PEM File
-
-For deployments that need a stable `cnf.jkt` thumbprint across process restarts, provide a 
-PEM-encoded private key:
-
-```properties
-rest.auth.oauth2.dpop.enabled=true
-rest.auth.oauth2.dpop.algorithm=ES256
-rest.auth.oauth2.dpop.private-key=/etc/authmgr/dpop-key.pem
-```
-
-The file must be in PEM format. The following formats are always supported:
-
-1. RSA or EC (Elliptic Curve) keys in PKCS#8 format (`BEGIN PRIVATE KEY`)
-
-If the BouncyCastle library is available at runtime, the following formats are also supported:
-
-2. RSA keys in PKCS#1 format (`BEGIN RSA PRIVATE KEY`)
-3. EC (Elliptic Curve) keys in EC SEC 1 format (`BEGIN EC PRIVATE KEY`)
-
-Only unencrypted private keys are supported.
-
-By default, the public key is derived from the private key at load time; this always works for RSA
-keys but requires BouncyCastle on the classpath for EC keys. To avoid the BouncyCastle dependency,
-supply the public key explicitly via `rest.auth.oauth2.dpop.public-key`:
-
-```properties
-rest.auth.oauth2.dpop.enabled=true
-rest.auth.oauth2.dpop.algorithm=ES256
-rest.auth.oauth2.dpop.private-key=/etc/authmgr/dpop-key.pem
-rest.auth.oauth2.dpop.public-key=/etc/authmgr/dpop-key.pub.pem
-```
-
-The public-key file must contain an X.509 `SubjectPublicKeyInfo` block
-(`-----BEGIN PUBLIC KEY-----`), as produced by `openssl pkey -pubout`.
 
 ## Signing Algorithms
 
@@ -130,8 +93,7 @@ which produces the smallest proofs.
 
 `ES256K` (secp256k1) and the `EdDSA` family (Ed25519 / Ed448) are not currently supported.
 
-For an ephemeral keypair the AuthManager generates a key matching the configured algorithm. For a
-static PEM key, the key type must match the algorithm family (EC for `ES*`, RSA for `RS*`/`PS*`).
+The AuthManager generates a key matching the configured algorithm.
 
 ## Nonce Handling
 
@@ -154,9 +116,7 @@ No configuration is needed — nonce challenges are handled automatically for th
   Iceberg HTTPClient grows an interception hook. (Token-endpoint nonce challenges — which go through
   the AuthManager's own HTTP client — *are* supported.)
 
-* **No key rotation.** An ephemeral key lives as long as the agent; a static key lives as long as
-  the PEM file points at it. To rotate, restart the process (for ephemeral keys) or replace the PEM
-  file and restart (for static keys).
+* **No key rotation.** The key lives as long as the agent. To rotate, restart the process.
 
 ## Full Configuration Reference
 

--- a/oauth2/core/src/docs/java/com/dremio/iceberg/authmgr/oauth2/docs/DocumentationGenerator.java
+++ b/oauth2/core/src/docs/java/com/dremio/iceberg/authmgr/oauth2/docs/DocumentationGenerator.java
@@ -292,7 +292,12 @@ public class DocumentationGenerator {
     }
 
     private String sanitizeSectionName(String className) {
-      return className.replace("Config", "").replaceAll("([A-Z])", " $1").trim() + " Settings";
+      return className
+              .replace("Config", "")
+              .replaceAll("([A-Z])", " $1")
+              .replace("Dpop", "DPoP")
+              .trim()
+          + " Settings";
     }
 
     private String resolvePrefix() {

--- a/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
+++ b/oauth2/core/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentKeycloakIT.java
@@ -20,7 +20,9 @@ import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLI
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLIENT_ID3;
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLIENT_ID4;
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLIENT_ID5;
+import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLIENT_ID6;
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLIENT_SECRET3;
+import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.CLIENT_SECRET6;
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.JWT_BEARER_ECDSA_ASSERTION_ISSUER;
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.SCOPE1;
 import static com.dremio.iceberg.authmgr.oauth2.test.junit.KeycloakExtension.createJwtBearerAssertion;
@@ -61,9 +63,12 @@ import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -213,8 +218,8 @@ public class OAuth2AgentKeycloakIT {
                 .grantType(initialGrantType)
                 .clientId(new ClientID(clientId))
                 .clientAuthenticationMethod(PRIVATE_KEY_JWT)
-                .jwsAlgorithm(algorithm)
-                .privateKey(privateKeyPath)
+                .jwtClientAuthAlgorithm(algorithm)
+                .jwtClientAuthPrivateKey(privateKeyPath)
                 .build();
         OAuth2Agent agent = env.newAgent()) {
       boolean expectRefreshToken =
@@ -503,6 +508,77 @@ public class OAuth2AgentKeycloakIT {
     }
   }
 
+  @CartesianTest
+  void dpop(
+      @Enum HttpClientType httpClientType,
+      @EnumLike(includes = {"client_credentials", "authorization_code"}) GrantType initialGrantType,
+      @EnumLike(includes = {"ES256", "RS256", "PS256"}) JWSAlgorithm dpopAlgorithm,
+      Builder envBuilder)
+      throws Exception {
+    try (TestEnvironment env =
+            envBuilder
+                .httpClientType(httpClientType)
+                .grantType(initialGrantType)
+                .clientAuthenticationMethod(CLIENT_SECRET_BASIC)
+                .clientId(new ClientID(CLIENT_ID6))
+                .clientSecret(new Secret(CLIENT_SECRET6))
+                .dpopEnabled(true)
+                .dpopAlgorithm(dpopAlgorithm)
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      AtomicReference<String> expectedJkt = new AtomicReference<>();
+      assertAgent(
+          agent,
+          tokens -> {
+            // RFC 9449 §5: all three flows (initial, refresh, renew) must emit a DPoP-bound token
+            // pinned to the same JWK the agent owns.
+            AccessToken accessToken = tokens.getTokens().getAccessToken();
+            soft.assertThat(accessToken.getType()).isEqualTo(AccessTokenType.DPOP);
+            JWT jwt = introspectToken(accessToken, CLIENT_ID6);
+            // Keycloak signals DPoP-bound tokens via token_type=DPoP on the token response.
+            // The access token itself (JWT) carries a cnf.jkt claim per RFC 9449 §6.
+            Map<String, Object> cnf = jwt.getJWTClaimsSet().getJSONObjectClaim("cnf");
+            soft.assertThat(cnf)
+                .as("cnf claim must be present on DPoP-bound access token")
+                .isNotNull();
+            String jkt = (String) cnf.get("jkt");
+            // SHA-256 in base64url is always 43 characters (32 bytes, no padding).
+            soft.assertThat(jkt)
+                .as("cnf.jkt must be a base64url-encoded SHA-256 JWK thumbprint")
+                .isNotNull()
+                .hasSize(43)
+                .matches("[A-Za-z0-9_-]+");
+            if (!expectedJkt.compareAndSet(null, jkt)) {
+              soft.assertThat(jkt).isEqualTo(expectedJkt.get());
+            }
+          },
+          initialGrantType != CLIENT_CREDENTIALS);
+    }
+  }
+
+  /**
+   * A bearer-only agent (no DPoP config) must fail against the DPoP-bound client: Keycloak rejects
+   * the token request for lack of a DPoP proof.
+   */
+  @Test
+  void dpopInvalidRequest(Builder envBuilder) {
+    try (TestEnvironment env =
+            envBuilder
+                .grantType(PASSWORD)
+                .clientAuthenticationMethod(CLIENT_SECRET_BASIC)
+                .clientId(new ClientID(CLIENT_ID6))
+                .clientSecret(new Secret(CLIENT_SECRET6))
+                .dpopEnabled(false)
+                .build();
+        OAuth2Agent agent = env.newAgent()) {
+      soft.assertThatThrownBy(agent::authenticate)
+          .asInstanceOf(type(OAuth2Exception.class))
+          .extracting(OAuth2Exception::getErrorObject)
+          .extracting(ErrorObject::getHTTPStatusCode, ErrorObject::getCode)
+          .containsExactly(400, "invalid_request");
+    }
+  }
+
   @Test
   void agentCopy(Builder envBuilder) throws Exception {
     try (TestEnvironment env = envBuilder.build();
@@ -588,27 +664,38 @@ public class OAuth2AgentKeycloakIT {
     }
   }
 
+  @FunctionalInterface
+  private interface TokensVerifier {
+    void verify(TokensResult tokens) throws Exception;
+  }
+
   private void assertAgent(OAuth2Agent agent, String clientId, boolean expectRefreshToken)
       throws Exception {
-    // initial grant
+    assertAgent(
+        agent,
+        tokens -> introspectToken(tokens.getTokens().getAccessToken(), clientId),
+        expectRefreshToken);
+  }
+
+  /** Walks an agent through its three token-producing flows: initial grant, refresh, and renew. */
+  private void assertAgent(OAuth2Agent agent, TokensVerifier verifier, boolean expectRefreshToken)
+      throws Exception {
     TokensResult initial = agent.authenticateInternal();
-    introspectToken(initial.getTokens().getAccessToken(), clientId);
-    // token refresh
+    verifier.verify(initial);
     if (expectRefreshToken) {
       // Refresh tokens without offline_access are bound by the user session;
       // Keycloak returns the refresh token expiration time in these cases.
       soft.assertThat(initial.getTokens().getRefreshToken()).isNotNull();
       soft.assertThat(initial.getRefreshTokenExpirationTime()).isNotNull();
       TokensResult refreshed = agent.refreshCurrentTokens(initial).toCompletableFuture().get();
-      introspectToken(refreshed.getTokens().getAccessToken(), clientId);
+      verifier.verify(refreshed);
       soft.assertThat(refreshed.getTokens().getRefreshToken()).isNotNull();
       soft.assertThat(refreshed.getRefreshTokenExpirationTime()).isNotNull();
     } else {
       soft.assertThat(initial.getTokens().getRefreshToken()).isNull();
     }
-    // fetch new tokens
     TokensResult renewed = agent.fetchNewTokens().toCompletableFuture().get();
-    introspectToken(renewed.getTokens().getAccessToken(), clientId);
+    verifier.verify(renewed);
     if (expectRefreshToken) {
       soft.assertThat(renewed.getTokens().getRefreshToken()).isNotNull();
       soft.assertThat(renewed.getRefreshTokenExpirationTime()).isNotNull();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Config.java
@@ -26,6 +26,7 @@ import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.DpopConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.HttpConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig;
@@ -74,6 +75,9 @@ public interface OAuth2Config {
 
   @WithName(JwtClientAuthConfig.GROUP_NAME)
   JwtClientAuthConfig getJwtClientAuthConfig();
+
+  @WithName(DpopConfig.GROUP_NAME)
+  DpopConfig getDpopConfig();
 
   @WithName(SystemConfig.GROUP_NAME)
   SystemConfig getSystemConfig();
@@ -125,6 +129,7 @@ public interface OAuth2Config {
     getTokenExchangeConfig().validate();
     getJwtBearerGrantConfig().validate();
     getJwtClientAuthConfig().validate();
+    getDpopConfig().validate();
     getSystemConfig().validate();
     getHttpConfig().validate();
     // Validate constraints that span multiple configuration classes

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Session.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Session.java
@@ -17,12 +17,12 @@ package com.dremio.iceberg.authmgr.oauth2;
 
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2Agent;
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.iceberg.rest.HTTPHeaders;
 import org.apache.iceberg.rest.HTTPHeaders.HTTPHeader;
 import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ImmutableHTTPHeaders;
 import org.apache.iceberg.rest.ImmutableHTTPRequest;
 import org.apache.iceberg.rest.auth.AuthSession;
 
@@ -55,9 +55,12 @@ public class OAuth2Session implements AuthSession {
 
   @Override
   public HTTPRequest authenticate(HTTPRequest request) {
-    AccessToken accessToken = agent.authenticate();
-    HTTPHeader authorization = HTTPHeader.of("Authorization", "Bearer " + accessToken.getValue());
-    HTTPHeaders newHeaders = request.headers().putIfAbsent(HTTPHeaders.of(authorization));
+    ImmutableHTTPHeaders.Builder authHeaders = ImmutableHTTPHeaders.builder();
+    agent.applyAuthentication(
+        request.method().name(),
+        request.requestUri(),
+        (name, value) -> authHeaders.addEntry(HTTPHeader.of(name, value)));
+    HTTPHeaders newHeaders = request.headers().putIfAbsent(authHeaders.build());
     return newHeaders.equals(request.headers())
         ? request
         : ImmutableHTTPRequest.builder().from(request).headers(newHeaders).build();

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
@@ -20,15 +20,20 @@ import static com.dremio.iceberg.authmgr.oauth2.concurrent.AutoCloseables.cancel
 import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
 import com.dremio.iceberg.authmgr.oauth2.concurrent.Futures;
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
+import com.dremio.iceberg.authmgr.oauth2.dpop.DpopContext;
+import com.dremio.iceberg.authmgr.oauth2.dpop.DpopScope;
 import com.dremio.iceberg.authmgr.oauth2.flow.Flow;
 import com.dremio.iceberg.authmgr.oauth2.flow.FlowFactory;
 import com.dremio.iceberg.authmgr.oauth2.flow.OAuth2Exception;
 import com.dremio.iceberg.authmgr.oauth2.flow.TokensResult;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.DPoPAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
 import jakarta.annotation.Nullable;
 import java.io.Closeable;
+import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -42,6 +47,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -149,6 +155,31 @@ public final class OAuth2Agent implements Closeable {
    */
   public OAuth2Agent copy() {
     return new OAuth2Agent(this);
+  }
+
+  /**
+   * Emits the authentication headers that should be applied to an outgoing request.
+   *
+   * <p>At minimum, this emits an {@code Authorization} header whose scheme matches the current
+   * access token's type (e.g. {@code Bearer} for standard tokens, {@code DPoP} for DPoP-bound
+   * tokens). When DPoP is enabled and the token is DPoP-bound, an additional {@code DPoP} header
+   * carries a fresh proof JWT bound to {@code httpMethod}, {@code requestUri}, and the access
+   * token.
+   *
+   * @param httpMethod the HTTP method of the outgoing request (e.g. {@code GET}, {@code POST}).
+   * @param requestUri the full URI of the outgoing request (used to populate the DPoP proof's
+   *     {@code htu} claim when applicable).
+   * @param headerConsumer the callback invoked once per header to apply.
+   */
+  public void applyAuthentication(
+      String httpMethod, URI requestUri, BiConsumer<String, String> headerConsumer) {
+    AccessToken token = authenticate();
+    headerConsumer.accept("Authorization", token.toAuthorizationHeader());
+    DpopContext dpop = flowFactory.getDpopContext();
+    if (dpop != null && token instanceof DPoPAccessToken) {
+      SignedJWT proof = dpop.createProof(DpopScope.RS, httpMethod, requestUri, token);
+      headerConsumer.accept("DPoP", proof.serialize());
+    }
   }
 
   /**

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2Agent.java
@@ -177,7 +177,8 @@ public final class OAuth2Agent implements Closeable {
     headerConsumer.accept("Authorization", token.toAuthorizationHeader());
     DpopContext dpop = flowFactory.getDpopContext();
     if (dpop != null && token instanceof DPoPAccessToken) {
-      SignedJWT proof = dpop.createProof(DpopScope.RS, httpMethod, requestUri, token);
+      SignedJWT proof =
+          dpop.createProof(DpopScope.RS, httpMethod, requestUri, (DPoPAccessToken) token);
       headerConsumer.accept("DPoP", proof.serialize());
     }
   }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtils.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigUtils.java
@@ -15,11 +15,14 @@
  */
 package com.dremio.iceberg.authmgr.oauth2.config;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class ConfigUtils {
@@ -43,6 +46,20 @@ public final class ConfigUtils {
 
   public static final List<CodeChallengeMethod> SUPPORTED_CODE_CHALLENGE_METHODS =
       List.of(CodeChallengeMethod.PLAIN, CodeChallengeMethod.S256);
+
+  /**
+   * EC algorithms supported for DPoP proof signing, each pinned to its unambiguous curve.
+   *
+   * <p>Nimbus's {@link Curve#forJWSAlgorithm(JWSAlgorithm)} returns a {@link Set} and can yield
+   * multiple entries (e.g. for {@code ES256K}), so we keep an explicit mapping here.
+   */
+  public static final Map<JWSAlgorithm, Curve> SUPPORTED_DPOP_EC_ALGORITHMS =
+      Map.of(
+          JWSAlgorithm.ES256, Curve.P_256,
+          JWSAlgorithm.ES384, Curve.P_384,
+          JWSAlgorithm.ES512, Curve.P_521);
+
+  public static final Set<JWSAlgorithm> SUPPORTED_DPOP_RSA_ALGORITHMS = JWSAlgorithm.Family.RSA;
 
   public static boolean requiresClientSecret(ClientAuthenticationMethod method) {
     return method.equals(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.config;
+
+import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
+import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
+import com.nimbusds.jose.JWSAlgorithm;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Configuration properties for <a href="https://datatracker.ietf.org/doc/html/rfc9449">RFC 9449:
+ * OAuth 2.0 Demonstrating Proof of Possession (DPoP)</a>.
+ *
+ * <p>When enabled, the agent generates or loads an asymmetric keypair and attaches a signed DPoP
+ * proof JWT to every request sent to the authorization server's token endpoint, as well as to every
+ * authenticated request sent to the protected resource server.
+ *
+ * <p>DPoP is disabled by default. To enable it, set {@code rest.auth.oauth2.dpop.enabled=true}.
+ */
+public interface DpopConfig {
+
+  String GROUP_NAME = "dpop";
+  String PREFIX = OAuth2Config.PREFIX + '.' + GROUP_NAME;
+
+  String ENABLED = "enabled";
+  String ALGORITHM = "algorithm";
+  String PRIVATE_KEY = "private-key";
+  String PUBLIC_KEY = "public-key";
+
+  String DEFAULT_ALGORITHM = "ES256";
+
+  /**
+   * Whether DPoP support is enabled. Defaults to {@code false}.
+   *
+   * <p>When enabled, every request to the token endpoint and every authenticated request to the
+   * resource server will carry a {@code DPoP} header with a signed proof JWT, and the {@code
+   * Authorization} header scheme for resource-server requests will switch from {@code Bearer} to
+   * {@code DPoP}.
+   */
+  @WithName(ENABLED)
+  @WithDefault("false")
+  boolean isEnabled();
+
+  /**
+   * The JWS algorithm to use for signing DPoP proof JWTs. Defaults to {@value #DEFAULT_ALGORITHM}.
+   *
+   * <p>Per RFC 9449, the signing key MUST be asymmetric; thus only asymmetric algorithms are
+   * accepted (e.g. {@code ES256}, {@code ES384}, {@code ES512}, {@code RS256}, {@code PS256},
+   * etc.). {@code ES256K} and the {@code EdDSA} family are not currently supported.
+   *
+   * <p>Algorithm names must match the "alg" Param Value as described in <a
+   * href="https://datatracker.ietf.org/doc/html/rfc7518#section-3.1">RFC 7518 Section 3.1</a>.
+   */
+  @WithName(ALGORITHM)
+  @WithDefault(DEFAULT_ALGORITHM)
+  JWSAlgorithm getAlgorithm();
+
+  /**
+   * The path on the local filesystem to the private key to use for signing DPoP proofs. Optional.
+   *
+   * <p>If not set, a fresh ephemeral keypair matching the configured {@value #ALGORITHM} is
+   * generated when the agent starts and discarded on shutdown.
+   *
+   * <p>If set, the file must be in PEM format; it may contain a private key, or a private key and a
+   * certificate chain. Only the private key is used.
+   *
+   * <p>Supported key formats are:
+   *
+   * <ul>
+   *   <li>RSA & ECDSA in PKCS#8 format ({@code BEGIN PRIVATE KEY}): always supported
+   *   <li>RSA in PKCS#1 format ({@code BEGIN RSA PRIVATE KEY}): requires the BouncyCastle library
+   *   <li>ECDSA in EC SEC 1 format ({@code BEGIN EC PRIVATE KEY}): requires the BouncyCastle
+   *       library
+   * </ul>
+   *
+   * Only unencrypted keys are supported currently.
+   */
+  @WithName(PRIVATE_KEY)
+  Optional<Path> getPrivateKey();
+
+  /**
+   * The path on the local filesystem to an optional public key PEM file accompanying {@value
+   * #PRIVATE_KEY}. Optional.
+   *
+   * <p>When set, the file must contain a {@code -----BEGIN PUBLIC KEY-----} block (X.509
+   * SubjectPublicKeyInfo, as produced by {@code openssl pkey -pubout}) for the public counterpart
+   * of the configured private key. When not set, the public key is derived from the private key
+   * automatically; this always works for RSA keys but requires BouncyCastle on the runtime
+   * classpath for EC keys.
+   *
+   * <p>Ignored when {@value #PRIVATE_KEY} is not set (ephemeral mode).
+   */
+  @WithName(PUBLIC_KEY)
+  Optional<Path> getPublicKey();
+
+  default void validate() {
+    if (!isEnabled()) {
+      return;
+    }
+    ConfigValidator validator = new ConfigValidator();
+    JWSAlgorithm algorithm = getAlgorithm();
+    validator.check(
+        ConfigUtils.SUPPORTED_DPOP_RSA_ALGORITHMS.contains(algorithm)
+            || ConfigUtils.SUPPORTED_DPOP_EC_ALGORITHMS.containsKey(algorithm),
+        PREFIX + '.' + ALGORITHM,
+        "DPoP: unsupported JWS algorithm '%s', must be an RSA or EC algorithm",
+        algorithm.getName());
+    validator.checkAlgorithm(algorithm);
+    if (getPrivateKey().isPresent()) {
+      validator.check(
+          Files.isRegularFile(getPrivateKey().get()) && Files.isReadable(getPrivateKey().get()),
+          PREFIX + '.' + PRIVATE_KEY,
+          "DPoP: private key path '%s' is not a file or is not readable",
+          getPrivateKey().get());
+    }
+    if (getPublicKey().isPresent()) {
+      validator.check(
+          Files.isRegularFile(getPublicKey().get()) && Files.isReadable(getPublicKey().get()),
+          PREFIX + '.' + PUBLIC_KEY,
+          "DPoP: public key path '%s' is not a file or is not readable",
+          getPublicKey().get());
+    }
+    validator.validate();
+  }
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfig.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfig.java
@@ -20,15 +20,12 @@ import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
 import com.nimbusds.jose.JWSAlgorithm;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
 
 /**
  * Configuration properties for <a href="https://datatracker.ietf.org/doc/html/rfc9449">RFC 9449:
  * OAuth 2.0 Demonstrating Proof of Possession (DPoP)</a>.
  *
- * <p>When enabled, the agent generates or loads an asymmetric keypair and attaches a signed DPoP
+ * <p>When enabled, the agent generates an ephemeral asymmetric keypair and attaches a signed DPoP
  * proof JWT to every request sent to the authorization server's token endpoint, as well as to every
  * authenticated request sent to the protected resource server.
  *
@@ -41,8 +38,6 @@ public interface DpopConfig {
 
   String ENABLED = "enabled";
   String ALGORITHM = "algorithm";
-  String PRIVATE_KEY = "private-key";
-  String PUBLIC_KEY = "public-key";
 
   String DEFAULT_ALGORITHM = "ES256";
 
@@ -72,44 +67,6 @@ public interface DpopConfig {
   @WithDefault(DEFAULT_ALGORITHM)
   JWSAlgorithm getAlgorithm();
 
-  /**
-   * The path on the local filesystem to the private key to use for signing DPoP proofs. Optional.
-   *
-   * <p>If not set, a fresh ephemeral keypair matching the configured {@value #ALGORITHM} is
-   * generated when the agent starts and discarded on shutdown.
-   *
-   * <p>If set, the file must be in PEM format; it may contain a private key, or a private key and a
-   * certificate chain. Only the private key is used.
-   *
-   * <p>Supported key formats are:
-   *
-   * <ul>
-   *   <li>RSA & ECDSA in PKCS#8 format ({@code BEGIN PRIVATE KEY}): always supported
-   *   <li>RSA in PKCS#1 format ({@code BEGIN RSA PRIVATE KEY}): requires the BouncyCastle library
-   *   <li>ECDSA in EC SEC 1 format ({@code BEGIN EC PRIVATE KEY}): requires the BouncyCastle
-   *       library
-   * </ul>
-   *
-   * Only unencrypted keys are supported currently.
-   */
-  @WithName(PRIVATE_KEY)
-  Optional<Path> getPrivateKey();
-
-  /**
-   * The path on the local filesystem to an optional public key PEM file accompanying {@value
-   * #PRIVATE_KEY}. Optional.
-   *
-   * <p>When set, the file must contain a {@code -----BEGIN PUBLIC KEY-----} block (X.509
-   * SubjectPublicKeyInfo, as produced by {@code openssl pkey -pubout}) for the public counterpart
-   * of the configured private key. When not set, the public key is derived from the private key
-   * automatically; this always works for RSA keys but requires BouncyCastle on the runtime
-   * classpath for EC keys.
-   *
-   * <p>Ignored when {@value #PRIVATE_KEY} is not set (ephemeral mode).
-   */
-  @WithName(PUBLIC_KEY)
-  Optional<Path> getPublicKey();
-
   default void validate() {
     if (!isEnabled()) {
       return;
@@ -123,20 +80,6 @@ public interface DpopConfig {
         "DPoP: unsupported JWS algorithm '%s', must be an RSA or EC algorithm",
         algorithm.getName());
     validator.checkAlgorithm(algorithm);
-    if (getPrivateKey().isPresent()) {
-      validator.check(
-          Files.isRegularFile(getPrivateKey().get()) && Files.isReadable(getPrivateKey().get()),
-          PREFIX + '.' + PRIVATE_KEY,
-          "DPoP: private key path '%s' is not a file or is not readable",
-          getPrivateKey().get());
-    }
-    if (getPublicKey().isPresent()) {
-      validator.check(
-          Files.isRegularFile(getPublicKey().get()) && Files.isReadable(getPublicKey().get()),
-          PREFIX + '.' + PUBLIC_KEY,
-          "DPoP: public key path '%s' is not a file or is not readable",
-          getPublicKey().get());
-    }
     validator.validate();
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReader.java
@@ -16,13 +16,27 @@
 package com.dremio.iceberg.authmgr.oauth2.crypto;
 
 import java.io.Reader;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.EllipticCurve;
+import java.security.spec.InvalidKeySpecException;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
@@ -69,6 +83,88 @@ final class BouncyCastlePemReader implements PemReader {
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to read PEM file: " + file, e);
     }
+  }
+
+  /**
+   * Reads a public key from a PEM file. Supported key formats:
+   *
+   * <ul>
+   *   <li>RSA or EC X.509 SubjectPublicKeyInfo (BEGIN PUBLIC KEY)
+   * </ul>
+   *
+   * @param file the path to the PEM file containing the public key
+   * @return the public key
+   * @throws IllegalArgumentException if the file cannot be read or parsed, or doesn't contain a
+   *     valid public key
+   */
+  @Override
+  public PublicKey readPublicKey(Path file) {
+    try (Reader reader = Files.newBufferedReader(file);
+        PEMParser pemParser = new PEMParser(reader)) {
+      Object pemObject;
+      while ((pemObject = pemParser.readObject()) != null) {
+        PublicKey publicKey = extractPublicKey(pemObject);
+        if (publicKey != null) {
+          return publicKey;
+        }
+      }
+      throw new IllegalArgumentException("No public key found in file: " + file);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to read PEM file: " + file, e);
+    }
+  }
+
+  @Override
+  public PublicKey derivePublicKey(PrivateKey privateKey) {
+    if (privateKey instanceof RSAPrivateCrtKey) {
+      return JcaPemReader.deriveRsaPublicKey((RSAPrivateCrtKey) privateKey);
+    }
+    if (privateKey instanceof ECPrivateKey) {
+      return deriveEcPublicKey((ECPrivateKey) privateKey);
+    }
+    throw new IllegalArgumentException(
+        "Unsupported private key type: " + privateKey.getClass().getName());
+  }
+
+  /** Derives the public key using BouncyCastle EC arithmetic. */
+  private static PublicKey deriveEcPublicKey(ECPrivateKey ecPrivateKey) {
+    java.security.spec.ECParameterSpec jcaSpec = ecPrivateKey.getParams();
+    org.bouncycastle.math.ec.ECPoint bcG = getEcPoint(jcaSpec);
+    org.bouncycastle.math.ec.ECPoint bcQ = bcG.multiply(ecPrivateKey.getS()).normalize();
+    ECPoint jcaQ =
+        new ECPoint(bcQ.getAffineXCoord().toBigInteger(), bcQ.getAffineYCoord().toBigInteger());
+    try {
+      return KeyFactory.getInstance("EC").generatePublic(new ECPublicKeySpec(jcaQ, jcaSpec));
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+      throw new IllegalStateException("Failed to derive EC public key", e);
+    }
+  }
+
+  private static org.bouncycastle.math.ec.ECPoint getEcPoint(ECParameterSpec jcaSpec) {
+    EllipticCurve jcaCurve = jcaSpec.getCurve();
+    if (!(jcaCurve.getField() instanceof ECFieldFp)) {
+      throw new IllegalArgumentException(
+          "Only prime-field EC curves are supported for public key derivation");
+    }
+    BigInteger p = ((ECFieldFp) jcaCurve.getField()).getP();
+    BigInteger a = jcaCurve.getA();
+    BigInteger b = jcaCurve.getB();
+    BigInteger n = jcaSpec.getOrder();
+    BigInteger h = BigInteger.valueOf(jcaSpec.getCofactor());
+    ECCurve bcCurve = new ECCurve.Fp(p, a, b, n, h);
+    ECPoint jcaG = jcaSpec.getGenerator();
+    return bcCurve.createPoint(jcaG.getAffineX(), jcaG.getAffineY());
+  }
+
+  private static PublicKey extractPublicKey(Object pemObject) throws PEMException {
+    // Nimbus JOSE JWT uses "EC" as the algorithm name for EC keys,
+    // but BouncyCastle uses "ECDSA"; normalize to "EC" for compatibility.
+    JcaPEMKeyConverter converter =
+        new JcaPEMKeyConverter().setAlgorithmMapping(X9ObjectIdentifiers.id_ecPublicKey, "EC");
+    if (pemObject instanceof SubjectPublicKeyInfo) {
+      return converter.getPublicKey((SubjectPublicKeyInfo) pemObject);
+    }
+    return null;
   }
 
   private static PrivateKey extractPrivateKey(Object pemObject) throws PEMException {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReader.java
@@ -16,27 +16,15 @@
 package com.dremio.iceberg.authmgr.oauth2.crypto;
 
 import java.io.Reader;
-import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
-import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.RSAPrivateCrtKey;
-import java.security.spec.ECFieldFp;
-import java.security.spec.ECParameterSpec;
-import java.security.spec.ECPoint;
-import java.security.spec.ECPublicKeySpec;
-import java.security.spec.EllipticCurve;
-import java.security.spec.InvalidKeySpecException;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
@@ -112,48 +100,6 @@ final class BouncyCastlePemReader implements PemReader {
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to read PEM file: " + file, e);
     }
-  }
-
-  @Override
-  public PublicKey derivePublicKey(PrivateKey privateKey) {
-    if (privateKey instanceof RSAPrivateCrtKey) {
-      return JcaPemReader.deriveRsaPublicKey((RSAPrivateCrtKey) privateKey);
-    }
-    if (privateKey instanceof ECPrivateKey) {
-      return deriveEcPublicKey((ECPrivateKey) privateKey);
-    }
-    throw new IllegalArgumentException(
-        "Unsupported private key type: " + privateKey.getClass().getName());
-  }
-
-  /** Derives the public key using BouncyCastle EC arithmetic. */
-  private static PublicKey deriveEcPublicKey(ECPrivateKey ecPrivateKey) {
-    java.security.spec.ECParameterSpec jcaSpec = ecPrivateKey.getParams();
-    org.bouncycastle.math.ec.ECPoint bcG = getEcPoint(jcaSpec);
-    org.bouncycastle.math.ec.ECPoint bcQ = bcG.multiply(ecPrivateKey.getS()).normalize();
-    ECPoint jcaQ =
-        new ECPoint(bcQ.getAffineXCoord().toBigInteger(), bcQ.getAffineYCoord().toBigInteger());
-    try {
-      return KeyFactory.getInstance("EC").generatePublic(new ECPublicKeySpec(jcaQ, jcaSpec));
-    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-      throw new IllegalStateException("Failed to derive EC public key", e);
-    }
-  }
-
-  private static org.bouncycastle.math.ec.ECPoint getEcPoint(ECParameterSpec jcaSpec) {
-    EllipticCurve jcaCurve = jcaSpec.getCurve();
-    if (!(jcaCurve.getField() instanceof ECFieldFp)) {
-      throw new IllegalArgumentException(
-          "Only prime-field EC curves are supported for public key derivation");
-    }
-    BigInteger p = ((ECFieldFp) jcaCurve.getField()).getP();
-    BigInteger a = jcaCurve.getA();
-    BigInteger b = jcaCurve.getB();
-    BigInteger n = jcaSpec.getOrder();
-    BigInteger h = BigInteger.valueOf(jcaSpec.getCofactor());
-    ECCurve bcCurve = new ECCurve.Fp(p, a, b, n, h);
-    ECPoint jcaG = jcaSpec.getGenerator();
-    return bcCurve.createPoint(jcaG.getAffineX(), jcaG.getAffineY());
   }
 
   private static PublicKey extractPublicKey(Object pemObject) throws PEMException {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReader.java
@@ -20,9 +20,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
 final class JcaPemReader implements PemReader {
@@ -52,6 +58,42 @@ final class JcaPemReader implements PemReader {
     }
   }
 
+  @Override
+  public PublicKey readPublicKey(Path file) {
+    try {
+      byte[] encoded = Base64.decodeBase64(readPemEncodedPublicKey(file));
+      X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encoded);
+      InvalidKeySpecException toThrow = null;
+      for (String algorithm : ALGORITHMS) {
+        try {
+          return KeyFactory.getInstance(algorithm).generatePublic(keySpec);
+        } catch (InvalidKeySpecException e) {
+          if (toThrow == null) {
+            toThrow = e;
+          } else {
+            toThrow.addSuppressed(e);
+          }
+        }
+      }
+      throw toThrow;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to read PEM file: " + file, e);
+    }
+  }
+
+  @Override
+  public PublicKey derivePublicKey(PrivateKey privateKey) {
+    if (privateKey instanceof RSAPrivateCrtKey) {
+      return deriveRsaPublicKey((RSAPrivateCrtKey) privateKey);
+    }
+    if (privateKey instanceof ECPrivateKey) {
+      throw new IllegalStateException(
+          "Deriving an EC public key from a private key requires BouncyCastle on the classpath");
+    }
+    throw new IllegalArgumentException(
+        "Unsupported private key type: " + privateKey.getClass().getName());
+  }
+
   private static String readPemEncodedPrivateKey(Path file) throws IOException {
     StringBuilder keyBuilder = new StringBuilder();
     try (BufferedReader reader = Files.newBufferedReader(file)) {
@@ -71,5 +113,36 @@ final class JcaPemReader implements PemReader {
       throw new IllegalArgumentException("No private key found in file: " + file);
     }
     return keyBuilder.toString();
+  }
+
+  private static String readPemEncodedPublicKey(Path file) throws IOException {
+    StringBuilder keyBuilder = new StringBuilder();
+    try (BufferedReader reader = Files.newBufferedReader(file)) {
+      boolean started = false;
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.startsWith("-----BEGIN PUBLIC KEY")) {
+          started = true;
+        } else if (line.startsWith("-----END PUBLIC KEY")) {
+          break;
+        } else if (started) {
+          keyBuilder.append(line.trim());
+        }
+      }
+    }
+    if (keyBuilder.length() == 0) {
+      throw new IllegalArgumentException("No public key found in file: " + file);
+    }
+    return keyBuilder.toString();
+  }
+
+  static PublicKey deriveRsaPublicKey(RSAPrivateCrtKey privateKey) {
+    try {
+      return KeyFactory.getInstance("RSA")
+          .generatePublic(
+              new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPublicExponent()));
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+      throw new IllegalStateException("Failed to derive RSA public key", e);
+    }
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReader.java
@@ -20,14 +20,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
@@ -81,19 +77,6 @@ final class JcaPemReader implements PemReader {
     }
   }
 
-  @Override
-  public PublicKey derivePublicKey(PrivateKey privateKey) {
-    if (privateKey instanceof RSAPrivateCrtKey) {
-      return deriveRsaPublicKey((RSAPrivateCrtKey) privateKey);
-    }
-    if (privateKey instanceof ECPrivateKey) {
-      throw new IllegalStateException(
-          "Deriving an EC public key from a private key requires BouncyCastle on the classpath");
-    }
-    throw new IllegalArgumentException(
-        "Unsupported private key type: " + privateKey.getClass().getName());
-  }
-
   private static String readPemEncodedPrivateKey(Path file) throws IOException {
     StringBuilder keyBuilder = new StringBuilder();
     try (BufferedReader reader = Files.newBufferedReader(file)) {
@@ -134,15 +117,5 @@ final class JcaPemReader implements PemReader {
       throw new IllegalArgumentException("No public key found in file: " + file);
     }
     return keyBuilder.toString();
-  }
-
-  static PublicKey deriveRsaPublicKey(RSAPrivateCrtKey privateKey) {
-    try {
-      return KeyFactory.getInstance("RSA")
-          .generatePublic(
-              new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPublicExponent()));
-    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-      throw new IllegalStateException("Failed to derive RSA public key", e);
-    }
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/PemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/PemReader.java
@@ -17,6 +17,7 @@ package com.dremio.iceberg.authmgr.oauth2.crypto;
 
 import java.nio.file.Path;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 
 /** A reader for PEM files. */
 public interface PemReader {
@@ -38,9 +39,41 @@ public interface PemReader {
    * @param file the path to the PEM file containing the private key
    * @return the private key
    * @throws IllegalArgumentException if the file cannot be read, parsed, or doesn't contain a valid
-   *     RSA private key
+   *     private key
    */
   PrivateKey readPrivateKey(Path file);
+
+  /**
+   * Reads a public key from a PEM file.
+   *
+   * <p>RSA and ECDSA public keys in X.509 SubjectPublicKeyInfo format ({@code -----BEGIN PUBLIC
+   * KEY-----}, as produced by {@code openssl pkey -pubout}) are always supported.
+   *
+   * @param file the path to the PEM file containing the public key
+   * @return the public key
+   * @throws IllegalArgumentException if the file cannot be read or parsed, or doesn't contain a
+   *     valid public key
+   */
+  PublicKey readPublicKey(Path file);
+
+  /**
+   * Derives the public key corresponding to the given private key.
+   *
+   * <p>For RSA keys, derivation is possible with any JCA-compliant runtime: the modulus and public
+   * exponent are available from a standard PKCS#8-loaded {@link
+   * java.security.interfaces.RSAPrivateCrtKey}.
+   *
+   * <p>For EC keys, derivation requires elliptic-curve point multiplication, which the standard JCA
+   * API does not expose. Implementations that do not have access to an EC arithmetic library MUST
+   * throw {@link IllegalStateException}.
+   *
+   * @param privateKey the private key
+   * @return the corresponding public key
+   * @throws IllegalStateException if the public key cannot be derived (e.g. EC without a suitable
+   *     library)
+   * @throws IllegalArgumentException if the private key type is not supported
+   */
+  PublicKey derivePublicKey(PrivateKey privateKey);
 }
 
 final class PemReaderInternal {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/PemReader.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/crypto/PemReader.java
@@ -55,25 +55,6 @@ public interface PemReader {
    *     valid public key
    */
   PublicKey readPublicKey(Path file);
-
-  /**
-   * Derives the public key corresponding to the given private key.
-   *
-   * <p>For RSA keys, derivation is possible with any JCA-compliant runtime: the modulus and public
-   * exponent are available from a standard PKCS#8-loaded {@link
-   * java.security.interfaces.RSAPrivateCrtKey}.
-   *
-   * <p>For EC keys, derivation requires elliptic-curve point multiplication, which the standard JCA
-   * API does not expose. Implementations that do not have access to an EC arithmetic library MUST
-   * throw {@link IllegalStateException}.
-   *
-   * @param privateKey the private key
-   * @return the corresponding public key
-   * @throws IllegalStateException if the public key cannot be derived (e.g. EC without a suitable
-   *     library)
-   * @throws IllegalArgumentException if the private key type is not supported
-   */
-  PublicKey derivePublicKey(PrivateKey privateKey);
 }
 
 final class PemReaderInternal {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContext.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContext.java
@@ -17,7 +17,6 @@ package com.dremio.iceberg.authmgr.oauth2.dpop;
 
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.DpopConfig;
-import com.dremio.iceberg.authmgr.oauth2.crypto.PemReader;
 import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -31,12 +30,9 @@ import com.nimbusds.oauth2.sdk.dpop.DefaultDPoPProofFactory;
 import com.nimbusds.oauth2.sdk.id.JWTID;
 import com.nimbusds.oauth2.sdk.token.DPoPAccessToken;
 import com.nimbusds.openid.connect.sdk.Nonce;
-import jakarta.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.security.InvalidAlgorithmParameterException;
-import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -69,11 +65,7 @@ public abstract class DpopContext {
 
   public static DpopContext create(DpopConfig config, Clock clock) {
     JWSAlgorithm algorithm = config.getAlgorithm();
-    KeyPair keyPair =
-        config
-            .getPrivateKey()
-            .map(path -> loadKeyPair(path, config.getPublicKey().orElse(null), algorithm))
-            .orElseGet(() -> generateKeyPair(algorithm));
+    KeyPair keyPair = generateKeyPair(algorithm);
     JWK jwk = toJwk(algorithm, keyPair.getPublic(), keyPair.getPrivate());
     return ImmutableDpopContext.builder().jwk(jwk).algorithm(algorithm).clock(clock).build();
   }
@@ -162,32 +154,6 @@ public abstract class DpopContext {
     throw unsupportedAlgorithm(algorithm);
   }
 
-  private static KeyPair loadKeyPair(
-      Path privateKeyPath, @Nullable Path publicKeyPath, JWSAlgorithm algorithm) {
-    PemReader reader = PemReader.getInstance();
-    PrivateKey privateKey = reader.readPrivateKey(privateKeyPath);
-    checkKeyMatchesAlgorithm(privateKey, algorithm);
-    PublicKey publicKey;
-    if (publicKeyPath != null) {
-      publicKey = reader.readPublicKey(publicKeyPath);
-      checkKeyMatchesAlgorithm(publicKey, algorithm);
-    } else {
-      try {
-        publicKey = reader.derivePublicKey(privateKey);
-      } catch (IllegalStateException e) {
-        throw new IllegalStateException(
-            "DPoP: could not derive public key from private key. "
-                + "Either add BouncyCastle to the runtime classpath, or set "
-                + DpopConfig.PREFIX
-                + '.'
-                + DpopConfig.PUBLIC_KEY
-                + " to point at the public key PEM file.",
-            e);
-      }
-    }
-    return new KeyPair(publicKey, privateKey);
-  }
-
   private static JWK toJwk(JWSAlgorithm algorithm, PublicKey publicKey, PrivateKey privateKey) {
     Curve curve = ConfigUtils.SUPPORTED_DPOP_EC_ALGORITHMS.get(algorithm);
     if (curve != null) {
@@ -201,21 +167,6 @@ public abstract class DpopContext {
           .build();
     }
     throw unsupportedAlgorithm(algorithm);
-  }
-
-  private static void checkKeyMatchesAlgorithm(Key key, JWSAlgorithm algorithm) {
-    boolean rsaKey = key instanceof java.security.interfaces.RSAKey;
-    boolean ecKey = key instanceof java.security.interfaces.ECKey;
-    boolean rsaAlg = ConfigUtils.SUPPORTED_DPOP_RSA_ALGORITHMS.contains(algorithm);
-    boolean ecAlg = ConfigUtils.SUPPORTED_DPOP_EC_ALGORITHMS.containsKey(algorithm);
-    if (!((rsaKey && rsaAlg) || (ecKey && ecAlg))) {
-      throw new IllegalArgumentException(
-          String.format(
-              "DPoP: loaded %s key type %s is not compatible with algorithm %s",
-              key instanceof PrivateKey ? "private" : "public",
-              key.getClass().getSimpleName(),
-              algorithm.getName()));
-    }
   }
 
   private static IllegalArgumentException unsupportedAlgorithm(JWSAlgorithm algorithm) {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContext.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContext.java
@@ -29,7 +29,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.dpop.DPoPProofFactory;
 import com.nimbusds.oauth2.sdk.dpop.DefaultDPoPProofFactory;
 import com.nimbusds.oauth2.sdk.id.JWTID;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.DPoPAccessToken;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import jakarta.annotation.Nullable;
 import java.net.URI;
@@ -115,7 +115,7 @@ public abstract class DpopContext {
    * or fragment).
    */
   public SignedJWT createProof(
-      DpopScope scope, String method, URI uri, @Nullable AccessToken accessToken) {
+      DpopScope scope, String method, URI uri, DPoPAccessToken accessToken) {
     // RFC 9449 §7 requires proofs for resource-server requests to bind the access token via `ath`;
     // conversely, token-endpoint requests have no access token yet (§4.2).
     if (scope == DpopScope.RS && accessToken == null) {

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContext.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContext.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.dpop;
+
+import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
+import com.dremio.iceberg.authmgr.oauth2.config.DpopConfig;
+import com.dremio.iceberg.authmgr.oauth2.crypto.PemReader;
+import com.dremio.iceberg.authmgr.tools.immutables.AuthManagerImmutable;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.dpop.DPoPProofFactory;
+import com.nimbusds.oauth2.sdk.dpop.DefaultDPoPProofFactory;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import jakarta.annotation.Nullable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Clock;
+import java.util.Date;
+import java.util.Locale;
+import org.immutables.value.Value;
+
+/**
+ * Per-agent bundle holding the DPoP key material, proof factory, and nonce cache.
+ *
+ * <p>The key (and therefore the proof factory over it) is immutable for the lifetime of the agent;
+ * this is required by RFC 9449 §5, which binds issued refresh tokens to the public key used at
+ * issuance. Presenting a refresh token later requires a proof signed by the same key.
+ *
+ * <p>When an agent is copied (see {@link #copy()}), the key and proof factory are shared by
+ * reference. The nonce cache is deep-copied so each agent has independent mutable state.
+ */
+@AuthManagerImmutable
+public abstract class DpopContext {
+
+  private static final int RSA_KEY_SIZE_BITS = 2048;
+
+  public static DpopContext create(DpopConfig config, Clock clock) {
+    JWSAlgorithm algorithm = config.getAlgorithm();
+    KeyPair keyPair =
+        config
+            .getPrivateKey()
+            .map(path -> loadKeyPair(path, config.getPublicKey().orElse(null), algorithm))
+            .orElseGet(() -> generateKeyPair(algorithm));
+    JWK jwk = toJwk(algorithm, keyPair.getPublic(), keyPair.getPrivate());
+    return ImmutableDpopContext.builder().jwk(jwk).algorithm(algorithm).clock(clock).build();
+  }
+
+  protected abstract JWK getJwk();
+
+  protected abstract JWSAlgorithm getAlgorithm();
+
+  protected abstract Clock getClock();
+
+  @Value.Default
+  protected DPoPProofFactory getProofFactory() {
+    try {
+      return new DefaultDPoPProofFactory(getJwk(), getAlgorithm());
+    } catch (JOSEException e) {
+      throw new IllegalStateException("Failed to initialize DPoP proof factory", e);
+    }
+  }
+
+  @Value.Default
+  protected DpopNonceCache getNonceCache() {
+    return new DpopNonceCache();
+  }
+
+  /**
+   * Returns a new context that shares the key and proof factory with this one but has an
+   * independent nonce cache seeded with this cache's current entries.
+   */
+  public DpopContext copy() {
+    return ImmutableDpopContext.builder().from(this).nonceCache(getNonceCache().copy()).build();
+  }
+
+  /**
+   * Builds a fresh DPoP proof JWT for a request, using the origin's currently cached nonce, if any.
+   * When {@code accessToken} is non-null, the proof includes an {@code ath} claim binding the proof
+   * to that access token (RFC 9449 §7).
+   *
+   * <p>The {@code htu} claim is normalized per RFC 9449 §4.2 (scheme + authority + path, no query
+   * or fragment).
+   */
+  public SignedJWT createProof(
+      DpopScope scope, String method, URI uri, @Nullable AccessToken accessToken) {
+    // RFC 9449 §7 requires proofs for resource-server requests to bind the access token via `ath`;
+    // conversely, token-endpoint requests have no access token yet (§4.2).
+    if (scope == DpopScope.RS && accessToken == null) {
+      throw new IllegalArgumentException(
+          "DPoP proof for a resource-server request must carry an access token");
+    }
+    if (scope == DpopScope.AS && accessToken != null) {
+      throw new IllegalArgumentException(
+          "DPoP proof for a token-endpoint request must not carry an access token");
+    }
+    // RFC 9449 §4.2 / RFC 9110 §9.1: standardized HTTP method tokens are all-uppercase
+    String htm = method.toUpperCase(Locale.ROOT);
+    URI htu = normalizeHtu(uri);
+    Nonce nonce = getNonceCache().get(scope).orElse(null);
+    Date iat = Date.from(getClock().instant());
+    try {
+      return getProofFactory().createDPoPJWT(new JWTID(), htm, htu, iat, accessToken, nonce);
+    } catch (JOSEException e) {
+      throw new IllegalStateException("Failed to sign DPoP proof", e);
+    }
+  }
+
+  public void captureNonce(DpopScope scope, Nonce nonce) {
+    getNonceCache().put(scope, nonce);
+  }
+
+  private static KeyPair generateKeyPair(JWSAlgorithm algorithm) {
+    try {
+      Curve curve = ConfigUtils.SUPPORTED_DPOP_EC_ALGORITHMS.get(algorithm);
+      if (curve != null) {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec(curve.getStdName()));
+        return generator.generateKeyPair();
+      }
+      if (ConfigUtils.SUPPORTED_DPOP_RSA_ALGORITHMS.contains(algorithm)) {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(RSA_KEY_SIZE_BITS);
+        return generator.generateKeyPair();
+      }
+    } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+      throw new IllegalStateException(
+          "Failed to generate DPoP keypair for algorithm " + algorithm, e);
+    }
+    throw unsupportedAlgorithm(algorithm);
+  }
+
+  private static KeyPair loadKeyPair(
+      Path privateKeyPath, @Nullable Path publicKeyPath, JWSAlgorithm algorithm) {
+    PemReader reader = PemReader.getInstance();
+    PrivateKey privateKey = reader.readPrivateKey(privateKeyPath);
+    checkKeyMatchesAlgorithm(privateKey, algorithm);
+    PublicKey publicKey;
+    if (publicKeyPath != null) {
+      publicKey = reader.readPublicKey(publicKeyPath);
+      checkKeyMatchesAlgorithm(publicKey, algorithm);
+    } else {
+      try {
+        publicKey = reader.derivePublicKey(privateKey);
+      } catch (IllegalStateException e) {
+        throw new IllegalStateException(
+            "DPoP: could not derive public key from private key. "
+                + "Either add BouncyCastle to the runtime classpath, or set "
+                + DpopConfig.PREFIX
+                + '.'
+                + DpopConfig.PUBLIC_KEY
+                + " to point at the public key PEM file.",
+            e);
+      }
+    }
+    return new KeyPair(publicKey, privateKey);
+  }
+
+  private static JWK toJwk(JWSAlgorithm algorithm, PublicKey publicKey, PrivateKey privateKey) {
+    Curve curve = ConfigUtils.SUPPORTED_DPOP_EC_ALGORITHMS.get(algorithm);
+    if (curve != null) {
+      return new ECKey.Builder(curve, (ECPublicKey) publicKey)
+          .privateKey((ECPrivateKey) privateKey)
+          .build();
+    }
+    if (ConfigUtils.SUPPORTED_DPOP_RSA_ALGORITHMS.contains(algorithm)) {
+      return new RSAKey.Builder((RSAPublicKey) publicKey)
+          .privateKey((RSAPrivateKey) privateKey)
+          .build();
+    }
+    throw unsupportedAlgorithm(algorithm);
+  }
+
+  private static void checkKeyMatchesAlgorithm(Key key, JWSAlgorithm algorithm) {
+    boolean rsaKey = key instanceof java.security.interfaces.RSAKey;
+    boolean ecKey = key instanceof java.security.interfaces.ECKey;
+    boolean rsaAlg = ConfigUtils.SUPPORTED_DPOP_RSA_ALGORITHMS.contains(algorithm);
+    boolean ecAlg = ConfigUtils.SUPPORTED_DPOP_EC_ALGORITHMS.containsKey(algorithm);
+    if (!((rsaKey && rsaAlg) || (ecKey && ecAlg))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "DPoP: loaded %s key type %s is not compatible with algorithm %s",
+              key instanceof PrivateKey ? "private" : "public",
+              key.getClass().getSimpleName(),
+              algorithm.getName()));
+    }
+  }
+
+  private static IllegalArgumentException unsupportedAlgorithm(JWSAlgorithm algorithm) {
+    return new IllegalArgumentException(
+        "DPoP: unsupported algorithm '"
+            + algorithm.getName()
+            + "'; supported: ES256, ES384, ES512, RS256, RS384, RS512, PS256, PS384, PS512");
+  }
+
+  /**
+   * Strips query and fragment from the URI per RFC 9449 §4.2 so the resulting {@code htu} claim is
+   * deterministic regardless of how the caller built the URI. Defensive: Nimbus's proof factory may
+   * or may not normalize; doing it here guarantees RFC-compliant output.
+   */
+  private static URI normalizeHtu(URI uri) {
+    if (uri.getQuery() == null && uri.getFragment() == null) {
+      return uri;
+    }
+    try {
+      return new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid htu: " + uri, e);
+    }
+  }
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopNonceCache.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopNonceCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.dpop;
+
+import com.nimbusds.openid.connect.sdk.Nonce;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Per-scope cache for the most recently observed {@code DPoP-Nonce} value.
+ *
+ * <p>RFC 9449 §8 lets the authorization server or the resource server require the client to include
+ * a {@code nonce} claim in its DPoP proofs, supplying the current value via a {@code DPoP-Nonce}
+ * response header. Nonces are issuer-scoped — an AS nonce is not interchangeable with an RS nonce
+ * even when the two servers share an origin — so the cache is keyed by {@link DpopScope}. Per RFC,
+ * only the most recent nonce per issuer matters, so the cache holds at most one entry per scope
+ * (two in total).
+ */
+public final class DpopNonceCache {
+
+  private final ConcurrentMap<DpopScope, Nonce> byScope;
+
+  public DpopNonceCache() {
+    byScope = new ConcurrentHashMap<>();
+  }
+
+  private DpopNonceCache(DpopNonceCache toCopy) {
+    byScope = new ConcurrentHashMap<>(toCopy.byScope);
+  }
+
+  /** Returns the most recently observed nonce for the given scope, if any. */
+  public Optional<Nonce> get(DpopScope scope) {
+    return Optional.ofNullable(byScope.get(Objects.requireNonNull(scope, "scope")));
+  }
+
+  /** Stores {@code nonce} for the given scope, overwriting any prior value. */
+  public void put(DpopScope scope, Nonce nonce) {
+    byScope.put(Objects.requireNonNull(scope, "scope"), Objects.requireNonNull(nonce, "nonce"));
+  }
+
+  /**
+   * Returns a new cache pre-populated with this cache's current entries. Subsequent mutations on
+   * either cache are independent.
+   */
+  public DpopNonceCache copy() {
+    return new DpopNonceCache(this);
+  }
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopScope.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopScope.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.dpop;
+
+/**
+ * Identifies the issuer of a DPoP nonce (RFC 9449 §8). Nonces are issuer-scoped: a nonce issued by
+ * the authorization server is not interchangeable with one issued by the resource server.
+ */
+public enum DpopScope {
+  /** Authorization-server-issued nonces, applied to token-endpoint proofs. */
+  AS,
+  /** Resource-server-issued nonces, applied to resource-request proofs. */
+  RS
+}

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/AbstractFlow.java
@@ -23,6 +23,8 @@ import static com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.PRIVATE_KE
 import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
 import com.dremio.iceberg.authmgr.oauth2.crypto.PemReader;
+import com.dremio.iceberg.authmgr.oauth2.dpop.DpopContext;
+import com.dremio.iceberg.authmgr.oauth2.dpop.DpopScope;
 import com.dremio.iceberg.authmgr.oauth2.endpoint.EndpointProvider;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.nimbusds.jose.JOSEException;
@@ -51,6 +53,9 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.id.JWTID;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.DPoPTokenError;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import jakarta.annotation.Nullable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.security.PrivateKey;
@@ -93,6 +98,9 @@ abstract class AbstractFlow implements Flow {
     @CanIgnoreReturnValue
     B endpointProvider(EndpointProvider endpointProvider);
 
+    @CanIgnoreReturnValue
+    B dpopContext(@Nullable DpopContext dpopContext);
+
     F build();
   }
 
@@ -104,18 +112,28 @@ abstract class AbstractFlow implements Flow {
 
   abstract EndpointProvider getEndpointProvider();
 
+  @Nullable
+  abstract DpopContext getDpopContext();
+
   CompletionStage<TokensResult> invokeTokenEndpoint(AuthorizationGrant grant) {
     HTTPRequest request;
     try {
       TokenRequest.Builder builder = newTokenRequestBuilder(grant);
       request = builder.build().toHTTPRequest();
+      addDpopHeader(request);
     } catch (Exception e) {
       return CompletableFuture.failedFuture(e);
     }
-    return CompletableFuture.supplyAsync(() -> sendAndReceive(request), getRuntime().getExecutor())
-        .whenComplete((response, error) -> log(request, response, error))
+    return sendTokenRequest(request)
+        .thenCompose(response -> handleDpopNonceChallenge(request, response))
         .thenApply(this::parseTokenResponse)
         .thenApply(this::toTokensResult);
+  }
+
+  private CompletionStage<HTTPResponse> sendTokenRequest(HTTPRequest request) {
+    return CompletableFuture.supplyAsync(() -> sendAndReceive(request), getRuntime().getExecutor())
+        .whenComplete((response, error) -> log(request, response, error))
+        .thenApply(response -> handleDpopNonceHeader(request, response));
   }
 
   TokenRequest.Builder newTokenRequestBuilder(AuthorizationGrant grant) {
@@ -254,5 +272,52 @@ abstract class AbstractFlow implements Flow {
         Date.from(issuedAt),
         new JWTID(),
         extraClaims);
+  }
+
+  private void addDpopHeader(HTTPRequest request) {
+    DpopContext dpop = getDpopContext();
+    if (dpop != null) {
+      String method = request.getMethod() == null ? "POST" : request.getMethod().name();
+      // When used for token-endpoint requests, no access token should be included in the proof
+      SignedJWT proof = dpop.createProof(DpopScope.AS, method, request.getURI(), null);
+      request.setDPoP(proof);
+    }
+  }
+
+  private HTTPResponse handleDpopNonceHeader(HTTPRequest request, HTTPResponse response) {
+    DpopContext dpop = getDpopContext();
+    if (dpop != null) {
+      Nonce nonce = response.getDPoPNonce();
+      if (nonce != null && !nonce.getValue().isEmpty()) {
+        dpop.captureNonce(DpopScope.AS, nonce);
+      }
+    }
+    return response;
+  }
+
+  private CompletionStage<HTTPResponse> handleDpopNonceChallenge(
+      HTTPRequest request, HTTPResponse response) {
+    DpopContext dpop = getDpopContext();
+    if (dpop == null || !isUseDpopNonceError(response)) {
+      return CompletableFuture.completedFuture(response);
+    }
+    // Re-sign the proof with the new nonce and retry once.
+    addDpopHeader(request);
+    return sendTokenRequest(request);
+  }
+
+  private static boolean isUseDpopNonceError(HTTPResponse response) {
+    if (response.getStatusCode() != 400) {
+      return false;
+    }
+    try {
+      TokenResponse parsed = TokenResponse.parse(response);
+      return !parsed.indicatesSuccess()
+          && DPoPTokenError.USE_DPOP_NONCE
+              .getCode()
+              .equals(parsed.toErrorResponse().getErrorObject().getCode());
+    } catch (ParseException e) {
+      return false;
+    }
   }
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowFactory.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/flow/FlowFactory.java
@@ -17,6 +17,7 @@ package com.dremio.iceberg.authmgr.oauth2.flow;
 
 import com.dremio.iceberg.authmgr.oauth2.OAuth2Config;
 import com.dremio.iceberg.authmgr.oauth2.agent.OAuth2AgentRuntime;
+import com.dremio.iceberg.authmgr.oauth2.dpop.DpopContext;
 import com.dremio.iceberg.authmgr.oauth2.endpoint.EndpointProvider;
 import com.dremio.iceberg.authmgr.oauth2.http.HttpClient;
 import com.dremio.iceberg.authmgr.oauth2.jwtbearer.AssertionSupplier;
@@ -43,6 +44,7 @@ public abstract class FlowFactory implements AutoCloseable {
         .runtime(getRuntime())
         .endpointProvider(getEndpointProvider())
         .requestSender(getHttpClient())
+        .dpopContext(getDpopContext())
         .build();
   }
 
@@ -56,6 +58,7 @@ public abstract class FlowFactory implements AutoCloseable {
         .runtime(getRuntime())
         .endpointProvider(getEndpointProvider())
         .requestSender(getHttpClient())
+        .dpopContext(getDpopContext())
         .refreshToken(currentRefreshToken)
         .build();
   }
@@ -77,12 +80,14 @@ public abstract class FlowFactory implements AutoCloseable {
     SubjectTokenSupplier subjectTokenSupplier = getSubjectTokenSupplier();
     ActorTokenSupplier actorTokenSupplier = getActorTokenSupplier();
     AssertionSupplier assertionSupplier = getAssertionSupplier();
+    DpopContext dpopContext = getDpopContext();
     return ImmutableFlowFactory.builder()
         .from(this)
-        // Copy the suppliers to also create copies of their internal agents.
+        // Copy the suppliers and DPoP context to give the copy its own internal state.
         .subjectTokenSupplier(subjectTokenSupplier == null ? null : subjectTokenSupplier.copy())
         .actorTokenSupplier(actorTokenSupplier == null ? null : actorTokenSupplier.copy())
         .assertionSupplier(assertionSupplier == null ? null : assertionSupplier.copy())
+        .dpopContext(dpopContext == null ? null : dpopContext.copy())
         .build();
   }
 
@@ -123,6 +128,14 @@ public abstract class FlowFactory implements AutoCloseable {
     return !getConfig().getBasicConfig().getGrantType().equals(GrantType.TOKEN_EXCHANGE)
         ? null
         : ActorTokenSupplier.create(getConfig(), getRuntime());
+  }
+
+  @Value.Default
+  @Nullable
+  public DpopContext getDpopContext() {
+    return getConfig().getDpopConfig().isEnabled()
+        ? DpopContext.create(getConfig().getDpopConfig(), getRuntime().getClock())
+        : null;
   }
 
   private AbstractFlow.Builder<? extends Flow, ?> newInitialFlowBuilder() {

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2SessionTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/OAuth2SessionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2;
+
+import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_INITIAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import org.apache.iceberg.rest.HTTPHeaders.HTTPHeader;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
+import org.apache.iceberg.rest.ImmutableHTTPRequest;
+import org.junit.jupiter.api.Test;
+
+class OAuth2SessionTest {
+
+  @Test
+  void testDpop() throws Exception {
+    try (TestEnvironment env = TestEnvironment.builder().dpopEnabled(true).build();
+        OAuth2Session session = new OAuth2Session(env.getProperties(), env.getExecutor())) {
+
+      URI rsUri = env.getCatalogServerUrl().resolve("v1/namespaces/ns/tables");
+      HTTPRequest request =
+          ImmutableHTTPRequest.builder().baseUri(rsUri).method(HTTPMethod.GET).path("").build();
+
+      HTTPRequest authenticated = session.authenticate(request);
+
+      // Authorization header uses DPoP scheme.
+      assertThat(header(authenticated, "Authorization")).isEqualTo("DPoP " + ACCESS_TOKEN_INITIAL);
+
+      // DPoP proof header is present, with correct htm/htu and ath bound to the access token.
+      String dpopHeader = header(authenticated, "DPoP");
+      assertThat(dpopHeader).isNotNull();
+
+      JWTClaimsSet claims = SignedJWT.parse(dpopHeader).getJWTClaimsSet();
+      assertThat(claims.getStringClaim("htm")).isEqualTo("GET");
+      assertThat(claims.getStringClaim("htu")).isEqualTo(rsUri.toString());
+      byte[] expectedHash =
+          MessageDigest.getInstance("SHA-256")
+              .digest(ACCESS_TOKEN_INITIAL.getBytes(StandardCharsets.US_ASCII));
+      assertThat(claims.getStringClaim("ath")).isEqualTo(Base64URL.encode(expectedHash).toString());
+    }
+  }
+
+  private static String header(HTTPRequest request, String name) {
+    return request.headers().entries(name).stream().findFirst().map(HTTPHeader::value).orElse(null);
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/agent/OAuth2AgentTest.java
@@ -47,6 +47,10 @@ import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
 import com.dremio.iceberg.authmgr.oauth2.test.junit.EnumLike;
 import com.dremio.iceberg.authmgr.oauth2.test.user.UserBehavior;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
@@ -57,9 +61,12 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
 import com.nimbusds.oauth2.sdk.token.TypelessAccessToken;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
@@ -1028,6 +1035,46 @@ class OAuth2AgentTest {
       soft.assertThat(agent).extracting("sleeping", ATOMIC_BOOLEAN).isFalse();
       soft.assertThat(token.getValue()).isEqualTo(ACCESS_TOKEN_REFRESHED);
       soft.assertThat(currentRenewalTask.get()).isNotSameAs(renewalTask);
+    }
+  }
+
+  @Test
+  void testApplyAuthenticationBearer() {
+    try (TestEnvironment env = TestEnvironment.builder().build();
+        OAuth2Agent agent = env.newAgent()) {
+
+      Map<String, String> headers = new LinkedHashMap<>();
+      agent.applyAuthentication(
+          "GET", URI.create("https://rs.example.com/warehouse1"), headers::put);
+
+      soft.assertThat(headers).containsOnlyKeys("Authorization");
+      soft.assertThat(headers).containsEntry("Authorization", "Bearer " + ACCESS_TOKEN_INITIAL);
+    }
+  }
+
+  @Test
+  void testApplyAuthenticationDpop() throws Exception {
+    try (TestEnvironment env =
+            TestEnvironment.builder().dpopEnabled(true).dpopAlgorithm(JWSAlgorithm.ES256).build();
+        OAuth2Agent agent = env.newAgent()) {
+
+      URI rsUri = URI.create("https://rs.example.com/warehouse1");
+      Map<String, String> headers = new LinkedHashMap<>();
+      agent.applyAuthentication("GET", rsUri, headers::put);
+
+      soft.assertThat(headers).containsOnlyKeys("Authorization", "DPoP");
+      soft.assertThat(headers).containsEntry("Authorization", "DPoP " + ACCESS_TOKEN_INITIAL);
+
+      SignedJWT proof = SignedJWT.parse(headers.get("DPoP"));
+      JWTClaimsSet claims = proof.getJWTClaimsSet();
+      soft.assertThat(claims.getStringClaim("htm")).isEqualTo("GET");
+      soft.assertThat(claims.getStringClaim("htu")).isEqualTo(rsUri.toString());
+
+      byte[] expectedHash =
+          MessageDigest.getInstance("SHA-256")
+              .digest(ACCESS_TOKEN_INITIAL.getBytes(StandardCharsets.US_ASCII));
+      soft.assertThat(claims.getStringClaim("ath"))
+          .isEqualTo(Base64URL.encode(expectedHash).toString());
     }
   }
 

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfigTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.config;
+
+import static com.dremio.iceberg.authmgr.oauth2.config.DpopConfig.PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.dremio.iceberg.authmgr.oauth2.config.validator.ConfigValidator;
+import com.nimbusds.jose.JWSAlgorithm;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DpopConfigTest {
+
+  static Path tempFile;
+
+  @BeforeAll
+  static void createFile(@TempDir Path tempDir) throws IOException {
+    tempFile = Files.createTempFile(tempDir, "dpop-key", ".pem");
+  }
+
+  private static DpopConfig load(Map<String, String> properties) {
+    SmallRyeConfig smallRyeConfig =
+        new SmallRyeConfigBuilder()
+            .withMapping(DpopConfig.class, PREFIX)
+            .withSources(new MapBackedConfigSource("catalog-properties", properties, 1000) {})
+            .build();
+    return smallRyeConfig.getConfigMapping(DpopConfig.class, PREFIX);
+  }
+
+  @Test
+  void testDefaults() {
+    DpopConfig config = load(Map.of());
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getAlgorithm()).isEqualTo(JWSAlgorithm.ES256);
+    assertThat(config.getPrivateKey()).isEmpty();
+    assertThat(config.getPublicKey()).isEmpty();
+  }
+
+  @Test
+  void testEnabledEphemeral() {
+    DpopConfig config = load(Map.of(PREFIX + '.' + DpopConfig.ENABLED, "true"));
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getPrivateKey()).isEmpty();
+    config.validate();
+  }
+
+  @Test
+  void testEnabledWithPrivateKey() {
+    DpopConfig config =
+        load(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED, "true",
+                PREFIX + '.' + DpopConfig.ALGORITHM, "RS256",
+                PREFIX + '.' + DpopConfig.PRIVATE_KEY, tempFile.toString()));
+    assertThat(config.getAlgorithm()).isEqualTo(JWSAlgorithm.RS256);
+    assertThat(config.getPrivateKey()).hasValue(tempFile);
+    config.validate();
+  }
+
+  @Test
+  void testEnabledWithPrivateAndPublicKey() {
+    DpopConfig config =
+        load(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED,
+                "true",
+                PREFIX + '.' + DpopConfig.ALGORITHM,
+                "ES256",
+                PREFIX + '.' + DpopConfig.PRIVATE_KEY,
+                tempFile.toString(),
+                PREFIX + '.' + DpopConfig.PUBLIC_KEY,
+                tempFile.toString()));
+    assertThat(config.getPrivateKey()).hasValue(tempFile);
+    assertThat(config.getPublicKey()).hasValue(tempFile);
+    config.validate();
+  }
+
+  @Test
+  void testDisabledSkipsValidation() {
+    DpopConfig config =
+        load(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED, "false",
+                PREFIX + '.' + DpopConfig.ALGORITHM, "HS256",
+                PREFIX + '.' + DpopConfig.PRIVATE_KEY, "/nonexistent"));
+    config.validate();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testValidate(Map<String, String> properties, List<String> expected) {
+    DpopConfig config = load(properties);
+    assertThatIllegalArgumentException()
+        .isThrownBy(config::validate)
+        .withMessage(ConfigValidator.buildDescription(expected.stream()));
+  }
+
+  static Stream<Arguments> testValidate() {
+    return Stream.of(
+        Arguments.of(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED, "true",
+                PREFIX + '.' + DpopConfig.ALGORITHM, "HS256"),
+            List.of(
+                "DPoP: unsupported JWS algorithm 'HS256', must be an RSA or EC algorithm "
+                    + "(rest.auth.oauth2.dpop.algorithm)")),
+        Arguments.of(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED, "true",
+                PREFIX + '.' + DpopConfig.ALGORITHM, "EdDSA"),
+            List.of(
+                "DPoP: unsupported JWS algorithm 'EdDSA', must be an RSA or EC algorithm "
+                    + "(rest.auth.oauth2.dpop.algorithm)")),
+        Arguments.of(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED, "true",
+                PREFIX + '.' + DpopConfig.PRIVATE_KEY, "/invalid/path"),
+            List.of(
+                "DPoP: private key path '/invalid/path' is not a file or is not readable "
+                    + "(rest.auth.oauth2.dpop.private-key)")),
+        Arguments.of(
+            Map.of(
+                PREFIX + '.' + DpopConfig.ENABLED, "true",
+                PREFIX + '.' + DpopConfig.PUBLIC_KEY, "/invalid/pub"),
+            List.of(
+                "DPoP: public key path '/invalid/pub' is not a file or is not readable "
+                    + "(rest.auth.oauth2.dpop.public-key)")));
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfigTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/DpopConfigTest.java
@@ -24,27 +24,15 @@ import com.nimbusds.jose.JWSAlgorithm;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.common.MapBackedConfigSource;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DpopConfigTest {
-
-  static Path tempFile;
-
-  @BeforeAll
-  static void createFile(@TempDir Path tempDir) throws IOException {
-    tempFile = Files.createTempFile(tempDir, "dpop-key", ".pem");
-  }
 
   private static DpopConfig load(Map<String, String> properties) {
     SmallRyeConfig smallRyeConfig =
@@ -60,46 +48,12 @@ class DpopConfigTest {
     DpopConfig config = load(Map.of());
     assertThat(config.isEnabled()).isFalse();
     assertThat(config.getAlgorithm()).isEqualTo(JWSAlgorithm.ES256);
-    assertThat(config.getPrivateKey()).isEmpty();
-    assertThat(config.getPublicKey()).isEmpty();
   }
 
   @Test
-  void testEnabledEphemeral() {
+  void testEnabled() {
     DpopConfig config = load(Map.of(PREFIX + '.' + DpopConfig.ENABLED, "true"));
     assertThat(config.isEnabled()).isTrue();
-    assertThat(config.getPrivateKey()).isEmpty();
-    config.validate();
-  }
-
-  @Test
-  void testEnabledWithPrivateKey() {
-    DpopConfig config =
-        load(
-            Map.of(
-                PREFIX + '.' + DpopConfig.ENABLED, "true",
-                PREFIX + '.' + DpopConfig.ALGORITHM, "RS256",
-                PREFIX + '.' + DpopConfig.PRIVATE_KEY, tempFile.toString()));
-    assertThat(config.getAlgorithm()).isEqualTo(JWSAlgorithm.RS256);
-    assertThat(config.getPrivateKey()).hasValue(tempFile);
-    config.validate();
-  }
-
-  @Test
-  void testEnabledWithPrivateAndPublicKey() {
-    DpopConfig config =
-        load(
-            Map.of(
-                PREFIX + '.' + DpopConfig.ENABLED,
-                "true",
-                PREFIX + '.' + DpopConfig.ALGORITHM,
-                "ES256",
-                PREFIX + '.' + DpopConfig.PRIVATE_KEY,
-                tempFile.toString(),
-                PREFIX + '.' + DpopConfig.PUBLIC_KEY,
-                tempFile.toString()));
-    assertThat(config.getPrivateKey()).hasValue(tempFile);
-    assertThat(config.getPublicKey()).hasValue(tempFile);
     config.validate();
   }
 
@@ -108,9 +62,10 @@ class DpopConfigTest {
     DpopConfig config =
         load(
             Map.of(
-                PREFIX + '.' + DpopConfig.ENABLED, "false",
-                PREFIX + '.' + DpopConfig.ALGORITHM, "HS256",
-                PREFIX + '.' + DpopConfig.PRIVATE_KEY, "/nonexistent"));
+                PREFIX + '.' + DpopConfig.ENABLED,
+                "false",
+                PREFIX + '.' + DpopConfig.ALGORITHM,
+                "HS256"));
     config.validate();
   }
 
@@ -138,20 +93,6 @@ class DpopConfigTest {
                 PREFIX + '.' + DpopConfig.ALGORITHM, "EdDSA"),
             List.of(
                 "DPoP: unsupported JWS algorithm 'EdDSA', must be an RSA or EC algorithm "
-                    + "(rest.auth.oauth2.dpop.algorithm)")),
-        Arguments.of(
-            Map.of(
-                PREFIX + '.' + DpopConfig.ENABLED, "true",
-                PREFIX + '.' + DpopConfig.PRIVATE_KEY, "/invalid/path"),
-            List.of(
-                "DPoP: private key path '/invalid/path' is not a file or is not readable "
-                    + "(rest.auth.oauth2.dpop.private-key)")),
-        Arguments.of(
-            Map.of(
-                PREFIX + '.' + DpopConfig.ENABLED, "true",
-                PREFIX + '.' + DpopConfig.PUBLIC_KEY, "/invalid/pub"),
-            List.of(
-                "DPoP: public key path '/invalid/pub' is not a file or is not readable "
-                    + "(rest.auth.oauth2.dpop.public-key)")));
+                    + "(rest.auth.oauth2.dpop.algorithm)")));
   }
 }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReaderTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReaderTest.java
@@ -24,12 +24,16 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class BouncyCastlePemReaderTest {
@@ -138,6 +142,42 @@ class BouncyCastlePemReaderTest {
         TestCertificates.instance().getRsaCertificatePem(),
         TestCertificates.instance().getEcdsaPublicKeyPem(),
         TestCertificates.instance().getEcdsaCertificatePem());
+  }
+
+  @Test
+  void testReadRsaPublicKey() {
+    PublicKey publicKey =
+        new BouncyCastlePemReader().readPublicKey(TestCertificates.instance().getRsaPublicKeyPem());
+    assertThat(publicKey).isInstanceOf(RSAPublicKey.class);
+    assertThat(publicKey.getAlgorithm()).isEqualTo("RSA");
+  }
+
+  @Test
+  void testReadEcPublicKey() {
+    PublicKey publicKey =
+        new BouncyCastlePemReader()
+            .readPublicKey(TestCertificates.instance().getEcdsaPublicKeyPem());
+    assertThat(publicKey).isInstanceOf(ECPublicKey.class);
+    assertThat(publicKey.getAlgorithm()).isEqualTo("EC");
+  }
+
+  @ParameterizedTest
+  @MethodSource("derivableKeyPairs")
+  void testDerivePublicKey(Path privatePem, Path publicPem) {
+    BouncyCastlePemReader reader = new BouncyCastlePemReader();
+    PrivateKey privateKey = reader.readPrivateKey(privatePem);
+    PublicKey expected = reader.readPublicKey(publicPem);
+    PublicKey actual = reader.derivePublicKey(privateKey);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> derivableKeyPairs() {
+    TestCertificates certs = TestCertificates.instance();
+    return Stream.of(
+        Arguments.of(certs.getRsaPrivateKeyPkcs8Pem(), certs.getRsaPublicKeyPem()),
+        Arguments.of(certs.getRsaPrivateKeyPkcs1Pem(), certs.getRsaPublicKeyPem()),
+        Arguments.of(certs.getEcdsaPrivateKeyPkcs8Pem(), certs.getEcdsaPublicKeyPem()),
+        Arguments.of(certs.getEcdsaPrivateKeySec1Pem(), certs.getEcdsaPublicKeyPem()));
   }
 
   @Test

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReaderTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/BouncyCastlePemReaderTest.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class BouncyCastlePemReaderTest {
@@ -159,25 +158,6 @@ class BouncyCastlePemReaderTest {
             .readPublicKey(TestCertificates.instance().getEcdsaPublicKeyPem());
     assertThat(publicKey).isInstanceOf(ECPublicKey.class);
     assertThat(publicKey.getAlgorithm()).isEqualTo("EC");
-  }
-
-  @ParameterizedTest
-  @MethodSource("derivableKeyPairs")
-  void testDerivePublicKey(Path privatePem, Path publicPem) {
-    BouncyCastlePemReader reader = new BouncyCastlePemReader();
-    PrivateKey privateKey = reader.readPrivateKey(privatePem);
-    PublicKey expected = reader.readPublicKey(publicPem);
-    PublicKey actual = reader.derivePublicKey(privateKey);
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  static Stream<Arguments> derivableKeyPairs() {
-    TestCertificates certs = TestCertificates.instance();
-    return Stream.of(
-        Arguments.of(certs.getRsaPrivateKeyPkcs8Pem(), certs.getRsaPublicKeyPem()),
-        Arguments.of(certs.getRsaPrivateKeyPkcs1Pem(), certs.getRsaPublicKeyPem()),
-        Arguments.of(certs.getEcdsaPrivateKeyPkcs8Pem(), certs.getEcdsaPublicKeyPem()),
-        Arguments.of(certs.getEcdsaPrivateKeySec1Pem(), certs.getEcdsaPublicKeyPem()));
   }
 
   @Test

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReaderTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReaderTest.java
@@ -24,8 +24,11 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -123,6 +126,42 @@ class JcaPemReaderTest {
         .hasMessageContaining("Failed to read PEM file")
         .rootCause()
         .hasMessageContaining("No private key found in file");
+  }
+
+  @Test
+  void testReadRsaPublicKey() {
+    Path file = TestCertificates.instance().getRsaPublicKeyPem();
+    PublicKey publicKey = new JcaPemReader().readPublicKey(file);
+    assertThat(publicKey).isInstanceOf(RSAPublicKey.class);
+    assertThat(publicKey.getAlgorithm()).isEqualTo("RSA");
+  }
+
+  @Test
+  void testReadEcPublicKey() {
+    Path file = TestCertificates.instance().getEcdsaPublicKeyPem();
+    PublicKey publicKey = new JcaPemReader().readPublicKey(file);
+    assertThat(publicKey).isInstanceOf(ECPublicKey.class);
+    assertThat(publicKey.getAlgorithm()).isEqualTo("EC");
+  }
+
+  @Test
+  void testDeriveRsaPublicKey() {
+    JcaPemReader reader = new JcaPemReader();
+    PrivateKey privateKey =
+        reader.readPrivateKey(TestCertificates.instance().getRsaPrivateKeyPkcs8Pem());
+    PublicKey expected = reader.readPublicKey(TestCertificates.instance().getRsaPublicKeyPem());
+    PublicKey actual = reader.derivePublicKey(privateKey);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testDeriveEcPublicKeyRejected() {
+    JcaPemReader reader = new JcaPemReader();
+    PrivateKey privateKey =
+        reader.readPrivateKey(TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem());
+    assertThatThrownBy(() -> reader.derivePublicKey(privateKey))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("requires BouncyCastle");
   }
 
   @Test

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReaderTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/crypto/JcaPemReaderTest.java
@@ -145,26 +145,6 @@ class JcaPemReaderTest {
   }
 
   @Test
-  void testDeriveRsaPublicKey() {
-    JcaPemReader reader = new JcaPemReader();
-    PrivateKey privateKey =
-        reader.readPrivateKey(TestCertificates.instance().getRsaPrivateKeyPkcs8Pem());
-    PublicKey expected = reader.readPublicKey(TestCertificates.instance().getRsaPublicKeyPem());
-    PublicKey actual = reader.derivePublicKey(privateKey);
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void testDeriveEcPublicKeyRejected() {
-    JcaPemReader reader = new JcaPemReader();
-    PrivateKey privateKey =
-        reader.readPrivateKey(TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem());
-    assertThatThrownBy(() -> reader.derivePublicKey(privateKey))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("requires BouncyCastle");
-  }
-
-  @Test
   void testReadPemWithInvalidBase64() throws IOException {
     // Given
     Path invalidBase64File = tempDir.resolve("invalid-base64.pem");

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContextTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContextTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.dpop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dremio.iceberg.authmgr.oauth2.config.DpopConfig;
+import com.dremio.iceberg.authmgr.oauth2.test.TestCertificates;
+import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.token.DPoPAccessToken;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DpopContextTest {
+
+  private static final URI TOKEN_ENDPOINT = URI.create("https://as.example.com/token");
+
+  @ParameterizedTest
+  @MethodSource("ephemeralAlgorithms")
+  void testEphemeral(JWSAlgorithm algorithm) throws Exception {
+    DpopContext ctx =
+        DpopContext.create(
+            loadConfig(
+                Map.of(
+                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED,
+                    "true",
+                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM,
+                    algorithm.getName())),
+            Clock.systemUTC());
+    assertSignAndVerify(ctx);
+  }
+
+  static Stream<Arguments> ephemeralAlgorithms() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.ES256),
+        Arguments.of(JWSAlgorithm.ES384),
+        Arguments.of(JWSAlgorithm.ES512),
+        Arguments.of(JWSAlgorithm.RS256),
+        Arguments.of(JWSAlgorithm.PS256));
+  }
+
+  @Test
+  void testLoadRsaPkcs8() throws Exception {
+    Path pem = TestCertificates.instance().getRsaPrivateKeyPkcs8Pem();
+    DpopContext ctx =
+        DpopContext.create(
+            loadConfig(
+                Map.of(
+                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
+                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "RS256",
+                    DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, pem.toString())),
+            Clock.systemUTC());
+    assertSignAndVerify(ctx);
+  }
+
+  @Test
+  void testLoadEcPkcs8() throws Exception {
+    Path pem = TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem();
+    DpopContext ctx =
+        DpopContext.create(
+            loadConfig(
+                Map.of(
+                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
+                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "ES256",
+                    DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, pem.toString())),
+            Clock.systemUTC());
+    assertSignAndVerify(ctx);
+  }
+
+  @Test
+  void testLoadEcPkcs8WithExplicitPublicKey() throws Exception {
+    Path privPem = TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem();
+    Path pubPem = TestCertificates.instance().getEcdsaPublicKeyPem();
+    DpopContext ctx =
+        DpopContext.create(
+            loadConfig(
+                Map.of(
+                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED,
+                    "true",
+                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM,
+                    "ES256",
+                    DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY,
+                    privPem.toString(),
+                    DpopConfig.PREFIX + '.' + DpopConfig.PUBLIC_KEY,
+                    pubPem.toString())),
+            Clock.systemUTC());
+    assertSignAndVerify(ctx);
+  }
+
+  @Test
+  void testAlgorithmKeyMismatch() {
+    Path rsaPem = TestCertificates.instance().getRsaPrivateKeyPkcs8Pem();
+    DpopConfig config =
+        loadConfig(
+            Map.of(
+                DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
+                DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "ES256",
+                DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, rsaPem.toString()));
+
+    assertThatThrownBy(() -> DpopContext.create(config, Clock.systemUTC()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not compatible with algorithm ES256");
+  }
+
+  @Test
+  void testCopySharesKeyButIsolatesNonceCache() {
+    DpopContext original = newContext();
+    Nonce n1 = new Nonce("n-1");
+    Nonce n2 = new Nonce("n-2");
+    original.getNonceCache().put(DpopScope.AS, n1);
+
+    DpopContext copy = original.copy();
+
+    // immutable state shared by reference
+    assertThat(copy.getProofFactory()).isSameAs(original.getProofFactory());
+
+    // nonce cache seeded, but independent
+    assertThat(copy.getNonceCache()).isNotSameAs(original.getNonceCache());
+    assertThat(copy.getNonceCache().get(DpopScope.AS)).hasValue(n1);
+
+    copy.getNonceCache().put(DpopScope.AS, n2);
+    assertThat(original.getNonceCache().get(DpopScope.AS)).hasValue(n1);
+    assertThat(copy.getNonceCache().get(DpopScope.AS)).hasValue(n2);
+  }
+
+  @Test
+  void testCreateProofHeaderAndClaims() throws Exception {
+    DpopContext ctx = newContext();
+
+    SignedJWT proof = ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, null);
+
+    assertThat(proof.getHeader().getType().getType()).isEqualTo("dpop+jwt");
+    JWK jwk = proof.getHeader().getJWK();
+    assertThat(jwk).isNotNull();
+    assertThat(jwk.isPrivate()).isFalse();
+
+    JWTClaimsSet claims = proof.getJWTClaimsSet();
+    assertThat(claims.getJWTID()).isNotBlank();
+    assertThat(claims.getStringClaim("htm")).isEqualTo("POST");
+    assertThat(claims.getStringClaim("htu")).isEqualTo(TOKEN_ENDPOINT.toString());
+    assertThat(claims.getIssueTime()).isNotNull();
+    assertThat(claims.getStringClaim("ath")).isNull();
+    assertThat(claims.getStringClaim("nonce")).isNull();
+
+    JWSVerifier verifier = new ECDSAVerifier((ECKey) jwk);
+    assertThat(proof.verify(verifier)).isTrue();
+  }
+
+  @Test
+  void testCreateProofUsesInjectedClock() throws Exception {
+    DpopContext ctx =
+        DpopContext.create(enabledEcConfig(), Clock.fixed(TestConstants.NOW, ZoneOffset.UTC));
+
+    SignedJWT proof = ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, null);
+
+    assertThat(proof.getJWTClaimsSet().getIssueTime().toInstant()).isEqualTo(TestConstants.NOW);
+  }
+
+  @Test
+  void testCreateProofNormalizesHtu() throws Exception {
+    DpopContext ctx = newContext();
+
+    SignedJWT proof =
+        ctx.createProof(
+            DpopScope.AS, "POST", URI.create("https://as.example.com/token?x=1#f"), null);
+
+    assertThat(proof.getJWTClaimsSet().getStringClaim("htu"))
+        .isEqualTo("https://as.example.com/token");
+  }
+
+  @Test
+  void testCreateProofIncludesCachedAsNonce() throws Exception {
+    DpopContext ctx = newContext();
+    ctx.getNonceCache().put(DpopScope.AS, new Nonce("n-abc"));
+
+    SignedJWT proof = ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, null);
+
+    assertThat(proof.getJWTClaimsSet().getStringClaim("nonce")).isEqualTo("n-abc");
+  }
+
+  @Test
+  void testCreateProofForRsDoesNotUseAsNonce() throws Exception {
+    // Same-origin deployment: AS and RS behind the same proxy (http://host/). An AS-issued nonce
+    // must not leak into an RS proof.
+    DpopContext ctx = newContext();
+    ctx.getNonceCache().put(DpopScope.AS, new Nonce("n-as"));
+
+    SignedJWT proof =
+        ctx.createProof(
+            DpopScope.RS,
+            "GET",
+            URI.create("https://as.example.com/resource"),
+            new DPoPAccessToken("rs-token"));
+
+    assertThat(proof.getJWTClaimsSet().getStringClaim("nonce")).isNull();
+  }
+
+  @Test
+  void testCreateProofRejectsMismatchedScopeAndAccessToken() {
+    DpopContext ctx = newContext();
+
+    assertThatThrownBy(() -> ctx.createProof(DpopScope.RS, "GET", TOKEN_ENDPOINT, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resource-server request must carry an access token");
+
+    assertThatThrownBy(
+            () -> ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, new DPoPAccessToken("x")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("token-endpoint request must not carry an access token");
+  }
+
+  @Test
+  void testCreateProofNormalizesHtmToUppercase() throws Exception {
+    DpopContext ctx = newContext();
+
+    SignedJWT proof = ctx.createProof(DpopScope.AS, "get", TOKEN_ENDPOINT, null);
+
+    assertThat(proof.getJWTClaimsSet().getStringClaim("htm")).isEqualTo("GET");
+  }
+
+  @Test
+  void testCreateProofJtiUniquePerCall() throws Exception {
+    DpopContext ctx = newContext();
+
+    String jti1 =
+        ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, null).getJWTClaimsSet().getJWTID();
+    String jti2 =
+        ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, null).getJWTClaimsSet().getJWTID();
+
+    assertThat(jti1).isNotEqualTo(jti2);
+  }
+
+  @Test
+  void testCreateProofIncludesAthForAccessToken() throws Exception {
+    DpopContext ctx = newContext();
+    String tokenValue = "access-token-xyz";
+    DPoPAccessToken accessToken = new DPoPAccessToken(tokenValue);
+
+    SignedJWT proof =
+        ctx.createProof(
+            DpopScope.RS, "GET", URI.create("https://rs.example.com/warehouses"), accessToken);
+
+    JWTClaimsSet claims = proof.getJWTClaimsSet();
+    byte[] expectedHash =
+        MessageDigest.getInstance("SHA-256").digest(tokenValue.getBytes(StandardCharsets.US_ASCII));
+    assertThat(claims.getStringClaim("ath")).isEqualTo(Base64URL.encode(expectedHash).toString());
+    assertThat(claims.getStringClaim("htm")).isEqualTo("GET");
+    assertThat(claims.getStringClaim("htu")).isEqualTo("https://rs.example.com/warehouses");
+  }
+
+  @Test
+  void testCaptureNonceStoresInCacheByScope() {
+    DpopContext ctx = newContext();
+
+    ctx.captureNonce(DpopScope.AS, new Nonce("n-123"));
+
+    assertThat(ctx.getNonceCache().get(DpopScope.AS)).hasValue(new Nonce("n-123"));
+    assertThat(ctx.getNonceCache().get(DpopScope.RS)).isEmpty();
+  }
+
+  private static DpopContext newContext() {
+    return DpopContext.create(enabledEcConfig(), Clock.systemUTC());
+  }
+
+  private static DpopConfig enabledEcConfig() {
+    return loadConfig(
+        Map.of(
+            DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
+            DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "ES256"));
+  }
+
+  private static DpopConfig loadConfig(Map<String, String> properties) {
+    return new SmallRyeConfigBuilder()
+        .withMapping(DpopConfig.class, DpopConfig.PREFIX)
+        .withSources(new MapBackedConfigSource("test", properties, 1000) {})
+        .build()
+        .getConfigMapping(DpopConfig.class, DpopConfig.PREFIX);
+  }
+
+  private static void assertSignAndVerify(DpopContext ctx) throws Exception {
+    SignedJWT proof = ctx.createProof(DpopScope.AS, "POST", TOKEN_ENDPOINT, null);
+    JWK jwk = proof.getHeader().getJWK();
+    JWSVerifier verifier =
+        jwk instanceof ECKey ? new ECDSAVerifier((ECKey) jwk) : new RSASSAVerifier((RSAKey) jwk);
+    assertThat(proof.verify(verifier)).isTrue();
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContextTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopContextTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.dremio.iceberg.authmgr.oauth2.config.DpopConfig;
-import com.dremio.iceberg.authmgr.oauth2.test.TestCertificates;
 import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSVerifier;
@@ -37,7 +36,6 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.common.MapBackedConfigSource;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.ZoneOffset;
@@ -74,69 +72,6 @@ class DpopContextTest {
         Arguments.of(JWSAlgorithm.ES512),
         Arguments.of(JWSAlgorithm.RS256),
         Arguments.of(JWSAlgorithm.PS256));
-  }
-
-  @Test
-  void testLoadRsaPkcs8() throws Exception {
-    Path pem = TestCertificates.instance().getRsaPrivateKeyPkcs8Pem();
-    DpopContext ctx =
-        DpopContext.create(
-            loadConfig(
-                Map.of(
-                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
-                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "RS256",
-                    DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, pem.toString())),
-            Clock.systemUTC());
-    assertSignAndVerify(ctx);
-  }
-
-  @Test
-  void testLoadEcPkcs8() throws Exception {
-    Path pem = TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem();
-    DpopContext ctx =
-        DpopContext.create(
-            loadConfig(
-                Map.of(
-                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
-                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "ES256",
-                    DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, pem.toString())),
-            Clock.systemUTC());
-    assertSignAndVerify(ctx);
-  }
-
-  @Test
-  void testLoadEcPkcs8WithExplicitPublicKey() throws Exception {
-    Path privPem = TestCertificates.instance().getEcdsaPrivateKeyPkcs8Pem();
-    Path pubPem = TestCertificates.instance().getEcdsaPublicKeyPem();
-    DpopContext ctx =
-        DpopContext.create(
-            loadConfig(
-                Map.of(
-                    DpopConfig.PREFIX + '.' + DpopConfig.ENABLED,
-                    "true",
-                    DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM,
-                    "ES256",
-                    DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY,
-                    privPem.toString(),
-                    DpopConfig.PREFIX + '.' + DpopConfig.PUBLIC_KEY,
-                    pubPem.toString())),
-            Clock.systemUTC());
-    assertSignAndVerify(ctx);
-  }
-
-  @Test
-  void testAlgorithmKeyMismatch() {
-    Path rsaPem = TestCertificates.instance().getRsaPrivateKeyPkcs8Pem();
-    DpopConfig config =
-        loadConfig(
-            Map.of(
-                DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true",
-                DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, "ES256",
-                DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, rsaPem.toString()));
-
-    assertThatThrownBy(() -> DpopContext.create(config, Clock.systemUTC()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("not compatible with algorithm ES256");
   }
 
   @Test

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopNonceCacheTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/dpop/DpopNonceCacheTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.dpop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nimbusds.openid.connect.sdk.Nonce;
+import org.junit.jupiter.api.Test;
+
+class DpopNonceCacheTest {
+
+  private static final Nonce N_AS_1 = new Nonce("n-as-1");
+  private static final Nonce N_AS_2 = new Nonce("n-as-2");
+  private static final Nonce N_RS_1 = new Nonce("n-rs-1");
+
+  @Test
+  void testGetBeforePutIsEmpty() {
+    DpopNonceCache cache = new DpopNonceCache();
+    assertThat(cache.get(DpopScope.AS)).isEmpty();
+    assertThat(cache.get(DpopScope.RS)).isEmpty();
+  }
+
+  @Test
+  void testPutThenGet() {
+    DpopNonceCache cache = new DpopNonceCache();
+    cache.put(DpopScope.AS, N_AS_1);
+    assertThat(cache.get(DpopScope.AS)).hasValue(N_AS_1);
+  }
+
+  @Test
+  void testScopesAreIsolated() {
+    DpopNonceCache cache = new DpopNonceCache();
+    cache.put(DpopScope.AS, N_AS_1);
+    cache.put(DpopScope.RS, N_RS_1);
+
+    assertThat(cache.get(DpopScope.AS)).hasValue(N_AS_1);
+    assertThat(cache.get(DpopScope.RS)).hasValue(N_RS_1);
+  }
+
+  @Test
+  void testLastWriteWins() {
+    DpopNonceCache cache = new DpopNonceCache();
+    cache.put(DpopScope.AS, N_AS_1);
+    cache.put(DpopScope.AS, N_AS_2);
+    assertThat(cache.get(DpopScope.AS)).hasValue(N_AS_2);
+  }
+
+  @Test
+  void testCopyInheritsEntriesThenDiverges() {
+    DpopNonceCache original = new DpopNonceCache();
+    original.put(DpopScope.AS, N_AS_1);
+    original.put(DpopScope.RS, N_RS_1);
+
+    DpopNonceCache copy = original.copy();
+    assertThat(copy.get(DpopScope.AS)).hasValue(N_AS_1);
+    assertThat(copy.get(DpopScope.RS)).hasValue(N_RS_1);
+
+    copy.put(DpopScope.AS, N_AS_2);
+    assertThat(copy.get(DpopScope.AS)).hasValue(N_AS_2);
+    assertThat(original.get(DpopScope.AS)).hasValue(N_AS_1);
+  }
+}

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DpopFlowTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/flow/DpopFlowTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.iceberg.authmgr.oauth2.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.dremio.iceberg.authmgr.oauth2.test.TestConstants;
+import com.dremio.iceberg.authmgr.oauth2.test.TestEnvironment;
+import com.dremio.iceberg.authmgr.oauth2.test.TestServer;
+import com.dremio.iceberg.authmgr.oauth2.test.junit.EnumLike;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.mockserver.model.HttpRequest;
+
+class DpopFlowTest {
+
+  @CartesianTest
+  void testDpop(
+      @EnumLike ClientAuthenticationMethod authenticationMethod,
+      @EnumLike GrantType initialGrantType)
+      throws Exception {
+
+    assumeTrue(
+        authenticationMethod != ClientAuthenticationMethod.NONE
+            || initialGrantType != GrantType.CLIENT_CREDENTIALS);
+
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .clientAuthenticationMethod(authenticationMethod)
+                .grantType(initialGrantType)
+                .dpopEnabled(true)
+                .dpopAlgorithm(JWSAlgorithm.ES256)
+                .build();
+        FlowFactory flowFactory = env.newFlowFactory()) {
+
+      Flow flow = flowFactory.createInitialFlow();
+      flow.fetchNewTokens().toCompletableFuture().get();
+
+      HttpRequest[] recorded =
+          TestServer.getInstance()
+              .retrieveRecordedRequests(
+                  HttpRequest.request().withPath(env.getTokenEndpoint().getPath()));
+      assertThat(recorded).hasSizeGreaterThanOrEqualTo(1);
+
+      String dpopHeader = recorded[0].getFirstHeader("DPoP");
+      assertThat(dpopHeader).isNotBlank();
+
+      SignedJWT proof = SignedJWT.parse(dpopHeader);
+      assertThat(proof.getHeader().getType().getType()).isEqualTo("dpop+jwt");
+
+      JWK jwk = proof.getHeader().getJWK();
+      assertThat(jwk).isNotNull();
+      assertThat(jwk.isPrivate()).isFalse();
+
+      JWTClaimsSet claims = proof.getJWTClaimsSet();
+      assertThat(claims.getJWTID()).isNotBlank();
+      assertThat(claims.getStringClaim("htm")).isEqualTo("POST");
+      assertThat(claims.getStringClaim("htu")).isEqualTo(env.getTokenEndpoint().toString());
+      assertThat(claims.getIssueTime()).isEqualTo(TestConstants.NOW);
+
+      // Token endpoint requests don't present an access token: no ath claim.
+      assertThat(claims.getStringClaim("ath")).isNull();
+
+      JWSVerifier verifier = new ECDSAVerifier((ECKey) jwk);
+      assertThat(proof.verify(verifier)).isTrue();
+    }
+  }
+
+  @Test
+  void testDpopNonceChallengeTriggersRetryWithNonce() throws Exception {
+    try (TestEnvironment env =
+            TestEnvironment.builder()
+                .dpopEnabled(true)
+                .requireDpopNonce(true)
+                .dpopAlgorithm(JWSAlgorithm.ES256)
+                .build();
+        FlowFactory flowFactory = env.newFlowFactory()) {
+
+      Flow flow = flowFactory.createInitialFlow();
+      flow.fetchNewTokens().toCompletableFuture().get();
+
+      HttpRequest[] recorded =
+          TestServer.getInstance()
+              .retrieveRecordedRequests(
+                  HttpRequest.request().withPath(env.getTokenEndpoint().getPath()));
+      assertThat(recorded).hasSize(2);
+
+      // First proof: no nonce claim (cache is empty at this point).
+      JWTClaimsSet firstClaims =
+          SignedJWT.parse(recorded[0].getFirstHeader("DPoP")).getJWTClaimsSet();
+      assertThat(firstClaims.getStringClaim("nonce")).isNull();
+
+      // Second proof: nonce claim equals what the server supplied.
+      JWTClaimsSet secondClaims =
+          SignedJWT.parse(recorded[1].getFirstHeader("DPoP")).getJWTClaimsSet();
+      assertThat(secondClaims.getStringClaim("nonce")).isEqualTo(env.getDpopNonce());
+
+      // Second proof must also be a distinct JWT, not a replay.
+      assertThat(secondClaims.getJWTID()).isNotEqualTo(firstClaims.getJWTID());
+    }
+  }
+}

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -27,6 +27,7 @@ import com.dremio.iceberg.authmgr.oauth2.config.AuthorizationCodeConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.BasicConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.ConfigUtils;
 import com.dremio.iceberg.authmgr.oauth2.config.DeviceCodeConfig;
+import com.dremio.iceberg.authmgr.oauth2.config.DpopConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.HttpConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.JwtBearerConfig;
 import com.dremio.iceberg.authmgr.oauth2.config.JwtClientAuthConfig;
@@ -260,21 +261,66 @@ public abstract class TestEnvironment implements AutoCloseable {
   }
 
   @Value.Default
+  public Map<String, String> getProperties() {
+    return ImmutableMap.<String, String>builder()
+        .putAll(getBasicConfig())
+        .putAll(getResourceOwnerConfig())
+        .putAll(getAuthorizationCodeConfig())
+        .putAll(getDeviceCodeConfig())
+        .putAll(getTokenRefreshConfig())
+        .putAll(getTokenExchangeConfig())
+        .putAll(getJwtBearerGrantConfig())
+        .putAll(getJwtClientAuthConfig())
+        .putAll(getDpopConfig())
+        .putAll(getSystemConfig())
+        .putAll(getHttpConfig())
+        .build();
+  }
+
+  @Value.Default
   public OAuth2Config getOAuth2Config() {
-    Map<String, String> properties =
+    return OAuth2Config.from(getProperties());
+  }
+
+  @Value.Default
+  public Map<String, String> getDpopConfig() {
+    if (!isDpopEnabled()) {
+      return Map.of();
+    }
+    ImmutableMap.Builder<String, String> builder =
         ImmutableMap.<String, String>builder()
-            .putAll(getBasicConfig())
-            .putAll(getResourceOwnerConfig())
-            .putAll(getAuthorizationCodeConfig())
-            .putAll(getDeviceCodeConfig())
-            .putAll(getTokenRefreshConfig())
-            .putAll(getTokenExchangeConfig())
-            .putAll(getJwtBearerGrantConfig())
-            .putAll(getJwtClientAuthConfig())
-            .putAll(getSystemConfig())
-            .putAll(getHttpConfig())
-            .build();
-    return OAuth2Config.from(properties);
+            .put(DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true")
+            .put(DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, getDpopAlgorithm().getName());
+    getDpopPrivateKey()
+        .ifPresent(
+            v -> builder.put(DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, v.toString()));
+    getDpopPublicKey()
+        .ifPresent(v -> builder.put(DpopConfig.PREFIX + '.' + DpopConfig.PUBLIC_KEY, v.toString()));
+    return builder.build();
+  }
+
+  @Value.Default
+  public boolean isDpopEnabled() {
+    return false;
+  }
+
+  @Value.Default
+  public JWSAlgorithm getDpopAlgorithm() {
+    return JWSAlgorithm.ES256;
+  }
+
+  public abstract Optional<Path> getDpopPrivateKey();
+
+  public abstract Optional<Path> getDpopPublicKey();
+
+  @Value.Default
+  public String getDpopNonce() {
+    return "test-dpop-nonce";
+  }
+
+  @Value.Default
+  public boolean isRequireDpopNonce() {
+    return false;
   }
 
   @Value.Default
@@ -695,12 +741,12 @@ public abstract class TestEnvironment implements AutoCloseable {
   @Value.Default
   public Map<String, String> getJwtClientAuthConfig() {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    getJwsAlgorithm()
+    getJwtClientAuthAlgorithm()
         .ifPresent(
             v ->
                 builder.put(
                     JwtClientAuthConfig.PREFIX + '.' + JwtClientAuthConfig.ALGORITHM, v.getName()));
-    getPrivateKey()
+    getJwtClientAuthPrivateKey()
         .ifPresent(
             v ->
                 builder.put(
@@ -709,9 +755,9 @@ public abstract class TestEnvironment implements AutoCloseable {
     return builder.build();
   }
 
-  public abstract Optional<JWSAlgorithm> getJwsAlgorithm();
+  public abstract Optional<JWSAlgorithm> getJwtClientAuthAlgorithm();
 
-  public abstract Optional<Path> getPrivateKey();
+  public abstract Optional<Path> getJwtClientAuthPrivateKey();
 
   @Value.Default
   public Map<String, String> getSystemConfig() {

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/TestEnvironment.java
@@ -284,19 +284,9 @@ public abstract class TestEnvironment implements AutoCloseable {
 
   @Value.Default
   public Map<String, String> getDpopConfig() {
-    if (!isDpopEnabled()) {
-      return Map.of();
-    }
-    ImmutableMap.Builder<String, String> builder =
-        ImmutableMap.<String, String>builder()
-            .put(DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, "true")
-            .put(DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, getDpopAlgorithm().getName());
-    getDpopPrivateKey()
-        .ifPresent(
-            v -> builder.put(DpopConfig.PREFIX + '.' + DpopConfig.PRIVATE_KEY, v.toString()));
-    getDpopPublicKey()
-        .ifPresent(v -> builder.put(DpopConfig.PREFIX + '.' + DpopConfig.PUBLIC_KEY, v.toString()));
-    return builder.build();
+    return Map.of(
+        DpopConfig.PREFIX + '.' + DpopConfig.ENABLED, String.valueOf(isDpopEnabled()),
+        DpopConfig.PREFIX + '.' + DpopConfig.ALGORITHM, getDpopAlgorithm().getName());
   }
 
   @Value.Default
@@ -308,10 +298,6 @@ public abstract class TestEnvironment implements AutoCloseable {
   public JWSAlgorithm getDpopAlgorithm() {
     return JWSAlgorithm.ES256;
   }
-
-  public abstract Optional<Path> getDpopPrivateKey();
-
-  public abstract Optional<Path> getDpopPublicKey();
 
   @Value.Default
   public String getDpopNonce() {

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AbstractTokenEndpointExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/AbstractTokenEndpointExpectation.java
@@ -55,8 +55,14 @@ public abstract class AbstractTokenEndpointExpectation extends AbstractExpectati
 
   protected HttpResponse response(
       HttpRequest httpRequest, String accessToken, String refreshToken) {
-    return HttpResponse.response()
-        .withBody(getJsonBody(responseBody(accessToken, refreshToken).build()));
+    HttpResponse response =
+        HttpResponse.response()
+            .withBody(getJsonBody(responseBody(accessToken, refreshToken).build()));
+    if (getTestEnvironment().isDpopEnabled()) {
+      // Simulate an AS that always advertises a fresh DPoP nonce (RFC 9449 §8).
+      response.withHeader("DPoP-Nonce", getTestEnvironment().getDpopNonce());
+    }
+    return response;
   }
 
   protected ImmutableList.Builder<Header> requestHeaders() {
@@ -94,10 +100,11 @@ public abstract class AbstractTokenEndpointExpectation extends AbstractExpectati
 
   protected ImmutableMap.Builder<String, Object> responseBody(
       String accessToken, String refreshToken) {
+    String tokenType = getTestEnvironment().isDpopEnabled() ? "DPoP" : "bearer";
     ImmutableMap.Builder<String, Object> builder =
         ImmutableMap.<String, Object>builder()
             .put("access_token", accessToken)
-            .put("token_type", "bearer")
+            .put("token_type", tokenType)
             .put("expires_in", getTestEnvironment().getAccessTokenLifespan().toSeconds());
     if (getTestEnvironment().isReturnRefreshTokens()) {
       builder.put("refresh_token", refreshToken);

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/InitialTokenFetchExpectation.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/expectation/InitialTokenFetchExpectation.java
@@ -19,6 +19,10 @@ import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.ACCESS_TOKEN_
 import static com.dremio.iceberg.authmgr.oauth2.test.TestConstants.REFRESH_TOKEN_INITIAL;
 
 import com.dremio.iceberg.authmgr.oauth2.test.TestServer;
+import com.nimbusds.jwt.SignedJWT;
+import java.text.ParseException;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
 
 public abstract class InitialTokenFetchExpectation extends AbstractTokenEndpointExpectation {
 
@@ -27,5 +31,33 @@ public abstract class InitialTokenFetchExpectation extends AbstractTokenEndpoint
     TestServer.getInstance()
         .when(request())
         .respond(httpRequest -> response(httpRequest, ACCESS_TOKEN_INITIAL, REFRESH_TOKEN_INITIAL));
+  }
+
+  @Override
+  protected HttpResponse response(
+      HttpRequest httpRequest, String accessToken, String refreshToken) {
+    if (getTestEnvironment().isDpopEnabled()
+        && getTestEnvironment().isRequireDpopNonce()
+        && !hasDpopNonce(httpRequest)) {
+      // Simulate an AS that demands a DPoP nonce (RFC 9449 §8)
+      return HttpResponse.response()
+          .withStatusCode(400)
+          .withHeader("Content-Type", "application/json")
+          .withHeader("DPoP-Nonce", getTestEnvironment().getDpopNonce())
+          .withBody("{\"error\":\"use_dpop_nonce\",\"error_description\":\"nonce required\"}");
+    }
+    return super.response(httpRequest, accessToken, refreshToken);
+  }
+
+  private static boolean hasDpopNonce(HttpRequest httpRequest) {
+    String dpopHeader = httpRequest.getFirstHeader("DPoP");
+    if (dpopHeader == null || dpopHeader.isEmpty()) {
+      return false;
+    }
+    try {
+      return SignedJWT.parse(dpopHeader).getJWTClaimsSet().getStringClaim("nonce") != null;
+    } catch (ParseException e) {
+      return false;
+    }
   }
 }

--- a/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/junit/KeycloakExtension.java
+++ b/oauth2/core/src/testFixtures/java/com/dremio/iceberg/authmgr/oauth2/test/junit/KeycloakExtension.java
@@ -74,6 +74,11 @@ public class KeycloakExtension extends TestEnvironmentExtension
   public static final String CLIENT_ID5 = "Client5";
   public static final String CLIENT_AUTH5 = PRIVATE_KEY_JWT.getValue();
 
+  // Client6 is used for DPoP-bound access tokens (RFC 9449) with client_secret_basic auth
+  public static final String CLIENT_ID6 = "Client6";
+  public static final String CLIENT_SECRET6 = "S6CR3T".repeat(10);
+  public static final String CLIENT_AUTH6 = CLIENT_SECRET_BASIC.getValue();
+
   public static final String USERNAME = TestConstants.USERNAME;
   public static final String PASSWORD = TestConstants.PASSWORD.getValue();
 
@@ -122,7 +127,8 @@ public class KeycloakExtension extends TestEnvironmentExtension
             .withClient(CLIENT_ID2, null, CLIENT_AUTH2)
             .withClient(CLIENT_ID3, CLIENT_SECRET3, CLIENT_AUTH3)
             .withClient(CLIENT_ID4, certs.getRsaCertificateBase64(), CLIENT_AUTH4)
-            .withClient(CLIENT_ID5, certs.getEcdsaCertificateBase64(), CLIENT_AUTH5);
+            .withClient(CLIENT_ID5, certs.getEcdsaCertificateBase64(), CLIENT_AUTH5)
+            .withClient(CLIENT_ID6, CLIENT_SECRET6, CLIENT_AUTH6, true);
     keycloak.start();
     context
         .getStore(ExtensionContext.Namespace.GLOBAL)

--- a/oauth2/tests/src/main/java/com/dremio/iceberg/authmgr/oauth2/test/container/KeycloakContainer.java
+++ b/oauth2/tests/src/main/java/com/dremio/iceberg/authmgr/oauth2/test/container/KeycloakContainer.java
@@ -79,6 +79,8 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
     withNetworkAliases("keycloak");
     withLogConsumer(new Slf4jLogConsumer(LOGGER));
     withEnv("KC_LOG_LEVEL", getRootLoggerLevel() + ",org.keycloak:" + getKeycloakLoggerLevel());
+    // DPoP is still a preview feature in Keycloak 26.x and must be enabled explicitly.
+    withFeaturesEnabled("dpop");
     // Useful when debugging Keycloak REST endpoints:
     addExposedPorts(5005);
     withEnv(
@@ -95,7 +97,13 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
   @CanIgnoreReturnValue
   public KeycloakContainer withClient(
       String clientId, String clientSecret, String authenticationMethod) {
-    clients.add(newClient(clientId, clientSecret, authenticationMethod));
+    return withClient(clientId, clientSecret, authenticationMethod, false);
+  }
+
+  @CanIgnoreReturnValue
+  public KeycloakContainer withClient(
+      String clientId, String clientSecret, String authenticationMethod, boolean dpopBound) {
+    clients.add(newClient(clientId, clientSecret, authenticationMethod, dpopBound));
     return this;
   }
 
@@ -306,7 +314,7 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
   }
 
   private static ClientRepresentation newClient(
-      String clientId, String clientSecret, String authenticationMethod) {
+      String clientId, String clientSecret, String authenticationMethod, boolean dpopBound) {
     ClientRepresentation client = new ClientRepresentation();
     String clientUuid = UUID.randomUUID().toString();
     client.setId(clientUuid);
@@ -324,6 +332,9 @@ public class KeycloakContainer extends ExtendableKeycloakContainer<KeycloakConta
             .put("oauth2.device.authorization.grant.enabled", "true")
             .put("standard.token.exchange.enabled", "true")
             .put("standard.token.exchange.enableRefreshRequestedTokenType", "SAME_SESSION");
+    if (dpopBound) {
+      attributes.put("dpop.bound.access.tokens", "true");
+    }
     switch (authenticationMethod) {
       case "client_secret_basic":
       case "client_secret_post":


### PR DESCRIPTION
This change adds support for Demonstrating Proof of Possession (DPoP). DPoP binds access tokens to an asymmetric keypair so stolen tokens cannot be replayed.

Summary of changes:

* Config layer (`DpopConfig`) with algorithm selection and optional   PEM-loaded private/public keys; ephemeral ES256 keypair by default.
* Proof management built on top of Nimbus's `DefaultDPoPProofFactory`, including a nonce cache.
* Token-endpoint integration inside `AbstractFlow.sendAndReceive` for all available grant types, including transparent retry on `use_dpop_nonce` errors.
* Resource-server integration in `OAuth2Session.authenticate`: switches the scheme to `DPoP` and adds a DPoP proof header when the access token is DPoP-typed.
* Unit tests (proof factory, nonce cache, config, flow) plus live Keycloak integration tests.
* User-facing documentation (`docs/dpop.md`).

Known limitation: resource-server nonce challenges (RFC 9449 §9) are not supported because the Iceberg `HTTPClient` does not surface 401 challenges to the AuthManager.