### PR TITLE
fix(build): pin JGit to 5.13.x for JReleaser

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -24,4 +24,12 @@ dependencies {
   implementation(baselibs.shadow)
   implementation(baselibs.spotless)
   implementation(baselibs.jreleaser)
+
+  // JReleaser 1.23.0 still references GpgObjectSigner, removed in JGit 7.x;
+  // Spotless 8.4.0 pulls JGit 7.x onto the same classpath. Force JGit to 5.13.x
+  // until JReleaser upgrades (https://github.com/jreleaser/jreleaser/issues/1846).
+  implementation("org.eclipse.jgit:org.eclipse.jgit") {
+    version { strictly("5.13.5.202508271544-r") }
+    because("JReleaser 1.23.0 references GpgObjectSigner removed in JGit 7.x")
+  }
 }


### PR DESCRIPTION
JReleaser 1.23.0 still references `org.eclipse.jgit.lib.GpgObjectSigner`, which was removed in JGit 7.x. Spotless 8.4.0 pulls JGit 7.x onto the build-logic classpath, so the release task fails with `NoClassDefFoundError`. Force JGit to 5.13.5 until JReleaser upgrades.

See https://github.com/jreleaser/jreleaser/issues/1846.