### PR TITLE
chore(build): Upgrade Iceberg to 1.11, use Java 17, bulk dependencies upgrade

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -25,11 +25,11 @@ dependencies {
   implementation(baselibs.spotless)
   implementation(baselibs.jreleaser)
 
-  // JReleaser 1.23.0 still references GpgObjectSigner, removed in JGit 7.x;
-  // Spotless 8.4.0 pulls JGit 7.x onto the same classpath. Force JGit to 5.13.x
+  // JReleaser still references GpgObjectSigner, removed in JGit 7.x;
+  // Spotless 8.5.1 pulls JGit 7.x onto the same classpath. Force JGit to 5.13.x
   // until JReleaser upgrades (https://github.com/jreleaser/jreleaser/issues/1846).
   implementation("org.eclipse.jgit:org.eclipse.jgit") {
     version { strictly("5.13.5.202508271544-r") }
-    because("JReleaser 1.23.0 references GpgObjectSigner removed in JGit 7.x")
+    because("JReleaser references GpgObjectSigner removed in JGit 7.x")
   }
 }

--- a/build-logic/src/main/kotlin/authmgr-bundle.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-bundle.gradle.kts
@@ -214,10 +214,10 @@ class BundleLicenseGenerator() : ReportRenderer {
   }
 }
 
-// Task to verify that the production JAR is compatible with Java 11
-val checkJava11Compatibility by
+// Task to verify that the production JAR is compatible with Java 17
+val checkJava17Compatibility by
   tasks.registering {
-    description = "Verifies that all classes in the production JAR are compatible with Java 11"
+    description = "Verifies that all classes in the production JAR are compatible with Java 17"
     group = "verification"
     dependsOn(shadowJar)
 
@@ -231,7 +231,7 @@ val checkJava11Compatibility by
       }
 
       val incompatibleClasses = mutableListOf<Pair<String, Int>>()
-      val maxJava11ClassVersion = 55 // Java 11 = class file version 55.0
+      val maxJava17ClassVersion = 61 // Java 17 = class file version 61.0
 
       ZipFile(jar).use { zip ->
         zip.stream().forEach { entry ->
@@ -242,7 +242,7 @@ val checkJava11Compatibility by
               // Extract major version (bytes 6-7)
               val bytes = input.readNBytes(2)
               val majorVersion = ((bytes[0].toInt() and 0xFF) shl 8) or (bytes[1].toInt() and 0xFF)
-              if (majorVersion > maxJava11ClassVersion) {
+              if (majorVersion > maxJava17ClassVersion) {
                 incompatibleClasses.add(Pair(entry.name, majorVersion))
               }
             }
@@ -253,7 +253,7 @@ val checkJava11Compatibility by
       if (incompatibleClasses.isNotEmpty()) {
         val errorMessage = buildString {
           appendLine(
-            "Found ${incompatibleClasses.size} class(es) incompatible with Java 11 in ${jar.name}:"
+            "Found ${incompatibleClasses.size} class(es) incompatible with Java 17 in ${jar.name}:"
           )
           incompatibleClasses
             .sortedBy { it.first }
@@ -266,4 +266,4 @@ val checkJava11Compatibility by
     }
   }
 
-tasks.named("check") { dependsOn(checkJava11Compatibility) }
+tasks.named("check") { dependsOn(checkJava17Compatibility) }

--- a/build-logic/src/main/kotlin/authmgr-java-production.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-java-production.gradle.kts
@@ -19,9 +19,9 @@ import org.gradle.api.tasks.compile.JavaCompile
 plugins { id("authmgr-java") }
 
 tasks.withType(JavaCompile::class.java).configureEach {
-  // Default to Java 11 for main sources, Java 21 for test sources
+  // Default to Java 17 for main sources, Java 21 for test sources
   if (name == "compileJava") {
-    options.release = 11
+    options.release = 17
   } else {
     options.release = 21
   }

--- a/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
+++ b/build-logic/src/main/kotlin/authmgr-jreleaser.gradle.kts
@@ -60,8 +60,10 @@ gradle.projectsEvaluated {
 
     signing {
       active.set(Active.ALWAYS)
-      verify.set(false) // requires the GPG public key to be set up
-      armored.set(true)
+      pgp {
+        verify.set(false) // requires the GPG public key to be set up
+        armored.set(true)
+      }
     }
 
     hooks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ if (System.getProperty("idea.sync.active").toBoolean()) {
 
 eclipse { project { name = ideName } }
 
-tasks.withType(JavaCompile::class.java).configureEach { options.release = 11 }
+tasks.withType(JavaCompile::class.java).configureEach { options.release = 17 }
 
 tasks.named<RatTask>("rat").configure {
   // These are Gradle file pattern syntax

--- a/docs/flink.md
+++ b/docs/flink.md
@@ -18,7 +18,7 @@ limitations under the License.
 ## Prerequisites
 
 * Apache Iceberg 1.9.0 or later is required.
-* Dremio AuthManager for Apache Iceberg requires Java 11 or later for runtime.
+* Dremio AuthManager for Apache Iceberg requires Java 17 or later for runtime.
 * Dremio AuthManager for Apache Iceberg is meant to be used in conjunction with an Iceberg engine
   runtime jar, e.g. `iceberg-flink-runtime-1.20`.
 

--- a/docs/spark.md
+++ b/docs/spark.md
@@ -18,7 +18,7 @@ limitations under the License.
 ## Prerequisites
 
 * Apache Iceberg 1.9.0 or later is required.
-* Dremio AuthManager for Apache Iceberg requires Java 11 or later for runtime.
+* Dremio AuthManager for Apache Iceberg requires Java 17 or later for runtime.
 * Dremio AuthManager for Apache Iceberg is meant to be used in conjunction with an Iceberg engine
   runtime jar, e.g. `iceberg-spark-runtime-3.5_2.12`.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ org.gradle.jvmargs=-Xms2g -Xmx4g -XX:MaxMetaspaceSize=768m
 # Matrix testing configuration for integration tests
 # Comma-separated list of versions to test against
 # The last version in the list is the default and will be used for the main intTest task
-authmgr.test.iceberg.versions=1.9.2,1.10.1
+authmgr.test.iceberg.versions=1.9.2,1.10.2,1.11.0
 authmgr.test.spark.versions=3.5.6,4.0.1
 authmgr.test.flink.versions=1.20.2,2.0.0
 authmgr.test.iceberg-connector.versions=1.9.2

--- a/gradle/baselibs.versions.toml
+++ b/gradle/baselibs.versions.toml
@@ -20,7 +20,7 @@
 [libraries]
 errorprone = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version = "5.1.0" }
 idea-ext = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext", version = "1.4.1" }
-jreleaser = { module = "org.jreleaser:jreleaser-gradle-plugin", version = "1.23.0" }
+jreleaser = { module = "org.jreleaser:jreleaser-gradle-plugin", version = "1.24.0" }
 license-report = { module = "com.github.jk1:gradle-license-report", version = "3.1.2" }
 shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "9.4.1" }
-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "8.4.0" }
+spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "8.5.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,11 +20,11 @@
 [versions]
 errorprone = "2.49.0"
 hadoop = "3.5.0"
-iceberg = "1.10.1" # When updating iceberg version, also update the iceberg test versions in gradle.properties
-immutables = "2.12.1"
+iceberg = "1.11.0" # When updating iceberg version, also update the iceberg test versions in gradle.properties
+immutables = "2.12.2"
 mockito = "5.23.0"
-mockserver = "5.15.0"
-nimbus-oauth2 = "11.37"
+mockserver = "6.0.0"
+nimbus-oauth2 = "11.37.2"
 nimbus-jose-jwt = "10.9"
 slf4j = "2.0.17"
 
@@ -39,20 +39,20 @@ slf4j = "2.0.17"
 assertj-core = { module = "org.assertj:assertj-core", version = "3.27.7" }
 awaitility = { module = "org.awaitility:awaitility", version = "4.3.0" }
 bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version = "1.84" }
-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.3" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.4" }
 errorprone = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone"  }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone" }
 guava = { module = "com.google.guava:guava", version = "33.6.0-jre" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
 hadoop-hdfs-client = { module = "org.apache.hadoop:hadoop-hdfs-client", version.ref = "hadoop" }
 hadoop-mapreduce-client-core = { module = "org.apache.hadoop:hadoop-mapreduce-client-core", version.ref = "hadoop" }
-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.6" }
+httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.6.1" }
 immutables-builder = { module = "org.immutables:builder", version.ref = "immutables" }
 immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 immutables-value-processor = { module = "org.immutables:value-processor", version.ref = "immutables" }
 iceberg-bom = { module = "org.apache.iceberg:iceberg-bom", version.ref = "iceberg" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
-junit-bom = { module = "org.junit:junit-bom", version = "6.0.0" }
+junit-bom = { module = "org.junit:junit-bom", version = "6.1.0" }
 junit-pioneer = { module = "org.junit-pioneer:junit-pioneer", version = "2.3.0" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version = "26.0.9" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.32" }
@@ -64,10 +64,9 @@ nimbus-oauth2-oidc-sdk = { module = "com.nimbusds:oauth2-oidc-sdk", version.ref 
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
 s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version = "5.0.0" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
-# Last version supporting JDK 11 https://github.com/smallrye/smallrye-config/pull/1287
-smallrye-config = { module = "io.smallrye.config:smallrye-config", version = { strictly = "3.10.2" } }
-testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "2.0.4" }
-testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "4.2.0" }
+smallrye-config = { module = "io.smallrye.config:smallrye-config", version = "3.17.2" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "2.0.5" }
+testcontainers-keycloak = { module = "com.github.dasniko:testcontainers-keycloak", version = "4.2.1" }
 
 [plugins]
 rat = { id = "org.nosphere.apache.rat", version = "0.8.1" }

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/config/ConfigRelocationInterceptorTest.java
@@ -193,16 +193,17 @@ class ConfigRelocationInterceptorTest {
                         "old-key"),
                     1000) {})
             .build();
-    assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.https")).isEqualTo("true");
-    assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.bind-port"))
+    assertThat(config.getConfigValue("rest.auth.oauth2.auth-code.callback.https").getValue())
+        .isEqualTo("true");
+    assertThat(config.getConfigValue("rest.auth.oauth2.auth-code.callback.bind-port").getValue())
         .isEqualTo("8080");
-    assertThat(config.getRawValue("rest.auth.oauth2.auth-code.callback.bind-host"))
+    assertThat(config.getConfigValue("rest.auth.oauth2.auth-code.callback.bind-host").getValue())
         .isEqualTo("localhost");
-    assertThat(config.getRawValue("rest.auth.oauth2.token-exchange.resources"))
+    assertThat(config.getConfigValue("rest.auth.oauth2.token-exchange.resources").getValue())
         .isEqualTo("urn:resource");
-    assertThat(config.getRawValue("rest.auth.oauth2.token-exchange.audiences"))
+    assertThat(config.getConfigValue("rest.auth.oauth2.token-exchange.audiences").getValue())
         .isEqualTo("urn:audience");
-    assertThat(config.getRawValue("rest.auth.oauth2.client-auth.jwt.private-key"))
+    assertThat(config.getConfigValue("rest.auth.oauth2.client-auth.jwt.private-key").getValue())
         .isEqualTo("old-key");
   }
 }

--- a/oauth2/kafka-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/kafka/KafkaKeycloakIT.java
+++ b/oauth2/kafka-tests/src/intTest/java/com/dremio/iceberg/authmgr/oauth2/test/kafka/KafkaKeycloakIT.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -173,7 +174,12 @@ public class KafkaKeycloakIT {
                 () -> icebergClient.loadTable(TableIdentifier.of(TEST_DB, TEST_TABLE)),
                 t -> t.snapshots().iterator().hasNext());
 
-    List<DataFile> files = Lists.newArrayList(table.currentSnapshot().addedDataFiles(table.io()));
+    List<DataFile> files =
+        Lists.newArrayList(
+            SnapshotChanges.builderFor(table)
+                .snapshot(table.currentSnapshot())
+                .build()
+                .addedDataFiles());
     assertThat(files).hasSize(2);
     assertThat(files.get(0).recordCount()).isEqualTo(1);
     assertThat(files.get(1).recordCount()).isEqualTo(1);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,8 +28,8 @@ if (authMangerBuild.exists()) {
   }
 }
 
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
-  throw GradleException("Build requires Java 11 or later")
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+  throw GradleException("Build requires Java 17 or later")
 }
 
 val baseVersion = file("version.txt").readText().trim()


### PR DESCRIPTION
This change upgrades Iceberg to 1.11. This makes Java 17 the new minimum required version for this project.

Other dependencies and plugins were also updated.