### PR TITLE
fix: re-read sessionCache inside synchronized block in getOrCreateSessionCache

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Manager.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/OAuth2Manager.java
@@ -136,7 +136,8 @@ public class OAuth2Manager implements AuthManager {
     AuthSessionCache cache = sessionCache;
     if (cache == null) {
       synchronized (this) {
-        if (sessionCache == null) {
+        cache = sessionCache;
+        if (cache == null) {
           OAuth2Config config = OAuth2Config.from(properties);
           cache = new AuthSessionCache(name, config.getSystemConfig().getSessionCacheTimeout());
           sessionCache = cache;


### PR DESCRIPTION
## Summary

`getOrCreateSessionCache()` in `OAuth2Manager` uses double-checked locking to lazily initialize `sessionCache`. The pattern had a bug: the local variable `cache` was not updated after another thread won the initialization race inside the `synchronized` block. The losing thread returned `null`, causing a `NullPointerException` at `cache.cachedSession()` in `tableSession()` (line 94).

## How it surfaces

The race triggers when multiple threads call `tableSession()` simultaneously before `sessionCache` is initialized. For example, when an Iceberg Kafka Connect sink flushes several Parquet files in parallel on the first commit interval.

This became consistently reproducible with `iceberg-kafka-connect` 1.11.0 after [apache/iceberg#13215](https://github.com/apache/iceberg/pull/13215) changed `S3V4RestSignerClient` to call `authManager().tableSession()` on every S3 request instead of caching the session per instance. Prior to 1.11.0, `tableSession()` was only called once at startup, so the race window never opened.

## Fix

Re-read `sessionCache` from the volatile field inside the `synchronized` block so the losing thread picks up the value set by the winner. This is the standard correction for this double-checked locking pattern.

