### PR TITLE
fix(jwt-bearer): Don't intern static tokens and assertions

### DIFF
--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplier.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplier.java
@@ -114,7 +114,12 @@ public abstract class AssertionSupplier implements AutoCloseable {
         getMainConfig().getJwtBearerGrantConfig().getAssertionConfig(), OAuth2Config.PREFIX);
   }
 
-  @Value.Derived
+  /**
+   * Returns the static assertion to use, if any (either inline, or read from an assertion file).
+   *
+   * @implNote This method should not be interned by {@code @Value.Derived} or similar annotations
+   *     because it may be called multiple times and the assertion file may change between calls.
+   */
   protected Optional<String> getStaticAssertion() {
     JwtBearerConfig jwtBearerConfig = getMainConfig().getJwtBearerGrantConfig();
     return jwtBearerConfig

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/AbstractTokenSupplier.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/AbstractTokenSupplier.java
@@ -128,15 +128,17 @@ public abstract class AbstractTokenSupplier implements AutoCloseable {
 
   protected abstract OAuth2AgentRuntime getRuntime();
 
-  @Value.Derived
+  /**
+   * Returns the static token to use, if any (either inline, or read from a token file).
+   *
+   * @implNote This method should not be interned by {@code @Value.Derived} or similar annotations
+   *     because it may be called multiple times and the token file may change between calls.
+   */
   protected abstract Optional<TypelessAccessToken> getStaticToken();
 
-  @Value.Derived
   protected abstract TokenTypeURI getTokenType();
 
-  @Value.Derived
   protected abstract Map<String, String> getDynamicTokenConfig();
 
-  @Value.Derived
   protected abstract String getDefaultAgentName();
 }

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/ActorTokenSupplier.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/ActorTokenSupplier.java
@@ -23,6 +23,7 @@ import com.nimbusds.oauth2.sdk.token.TokenTypeURI;
 import com.nimbusds.oauth2.sdk.token.TypelessAccessToken;
 import java.util.Map;
 import java.util.Optional;
+import org.immutables.value.Value;
 
 /** A component that centralizes the logic for supplying the actor token for token exchanges. */
 @AuthManagerImmutable
@@ -50,16 +51,19 @@ public abstract class ActorTokenSupplier extends AbstractTokenSupplier {
                 tokenExchangeConfig.getActorTokenFile().map(ActorTokenSupplier::readTokenFromFile));
   }
 
+  @Value.Derived
   @Override
   protected TokenTypeURI getTokenType() {
     return getMainConfig().getTokenExchangeConfig().getActorTokenType();
   }
 
+  @Value.Derived
   @Override
   protected Map<String, String> getDynamicTokenConfig() {
     return getMainConfig().getTokenExchangeConfig().getActorTokenConfig();
   }
 
+  @Value.Derived
   @Override
   protected String getDefaultAgentName() {
     return getMainConfig().getSystemConfig().getAgentName() + "-actor";

--- a/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/SubjectTokenSupplier.java
+++ b/oauth2/core/src/main/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/SubjectTokenSupplier.java
@@ -61,16 +61,19 @@ public abstract class SubjectTokenSupplier extends AbstractTokenSupplier {
                     .map(SubjectTokenSupplier::readTokenFromFile));
   }
 
+  @Value.Derived
   @Override
   protected TokenTypeURI getTokenType() {
     return getMainConfig().getTokenExchangeConfig().getSubjectTokenType();
   }
 
+  @Value.Derived
   @Override
   protected Map<String, String> getDynamicTokenConfig() {
     return getMainConfig().getTokenExchangeConfig().getSubjectTokenConfig();
   }
 
+  @Value.Derived
   @Override
   protected String getDefaultAgentName() {
     return getMainConfig().getSystemConfig().getAgentName() + "-subject";

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplierTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/jwtbearer/AssertionSupplierTest.java
@@ -92,6 +92,41 @@ class AssertionSupplierTest {
     }
   }
 
+  /**
+   * Guards against {@code getStaticAssertion()} being interned by {@code @Value.Derived}: the
+   * assertion file must be re-read on every call, so that a file rotated in place by an external
+   * process is picked up without restarting the agent.
+   */
+  @Test
+  void testSupplyAssertionAsyncFromRotatedFile(@TempDir Path tempDir) throws Exception {
+    Path assertionFile = tempDir.resolve("assertion.txt");
+    Files.writeString(assertionFile, "assertion-v1");
+    OAuth2Config config = createMainConfig(null, assertionFile, Map.of());
+    try (AssertionSupplier supplier = createSupplier(config)) {
+      assertThat(supplier.supplyAssertionAsync().toCompletableFuture().join())
+          .isEqualTo("assertion-v1");
+
+      Files.writeString(assertionFile, "  assertion-v2  ");
+
+      assertThat(supplier.supplyAssertionAsync().toCompletableFuture().join())
+          .isEqualTo("assertion-v2");
+    }
+  }
+
+  @Test
+  void testSupplyAssertionAsyncInlineAssertionTakesPrecedenceOverFile(@TempDir Path tempDir)
+      throws Exception {
+    Path assertionFile = tempDir.resolve("assertion.txt");
+    Files.writeString(assertionFile, "assertion-from-file");
+    OAuth2Config config = createMainConfig(ASSERTION_TOKEN, assertionFile, Map.of());
+    try (AssertionSupplier supplier = createSupplier(config)) {
+      // rotating or removing the file must not matter: the inline assertion wins
+      Files.delete(assertionFile);
+      assertThat(supplier.supplyAssertionAsync().toCompletableFuture().join())
+          .isEqualTo(ASSERTION_TOKEN);
+    }
+  }
+
   private static OAuth2Config createMainConfig(
       String assertion, Path assertionFile, Map<String, String> assertionConfig) {
     return OAuth2Config.from(createProperties(assertion, assertionFile, assertionConfig));

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/ActorTokenSupplierTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/ActorTokenSupplierTest.java
@@ -96,6 +96,43 @@ class ActorTokenSupplierTest {
     }
   }
 
+  /**
+   * Guards against {@code getStaticToken()} being interned by {@code @Value.Derived}: the token
+   * file must be re-read on every call, so that a file rotated in place by an external process is
+   * picked up without restarting the agent.
+   */
+  @Test
+  void testSupplyActorTokenAsyncFromRotatedFile(@TempDir Path tempDir) throws Exception {
+    Path tokenFile = tempDir.resolve("actor-token.txt");
+    Files.writeString(tokenFile, "actor-token-v1");
+    OAuth2Config config = createMainConfig(null, tokenFile, TokenTypeURI.JWT, Map.of());
+    try (ActorTokenSupplier supplier = createSupplier(config)) {
+      assertThat(supplier.supplyTokenAsync())
+          .isCompletedWithValue(new BearerAccessToken("actor-token-v1", 0, null, TokenTypeURI.JWT));
+
+      Files.writeString(tokenFile, "  actor-token-v2  ");
+
+      assertThat(supplier.supplyTokenAsync())
+          .isCompletedWithValue(new BearerAccessToken("actor-token-v2", 0, null, TokenTypeURI.JWT));
+    }
+  }
+
+  @Test
+  void testSupplyActorTokenAsyncInlineTokenTakesPrecedenceOverFile(@TempDir Path tempDir)
+      throws Exception {
+    Path tokenFile = tempDir.resolve("actor-token.txt");
+    Files.writeString(tokenFile, "actor-token-from-file");
+    OAuth2Config config =
+        createMainConfig("inline-actor-token", tokenFile, TokenTypeURI.JWT, Map.of());
+    try (ActorTokenSupplier supplier = createSupplier(config)) {
+      // rotating or removing the file must not matter: the inline token wins
+      Files.delete(tokenFile);
+      assertThat(supplier.supplyTokenAsync())
+          .isCompletedWithValue(
+              new BearerAccessToken("inline-actor-token", 0, null, TokenTypeURI.JWT));
+    }
+  }
+
   private static OAuth2Config createMainConfig(
       String actorToken,
       Path actorTokenFile,

--- a/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/SubjectTokenSupplierTest.java
+++ b/oauth2/core/src/test/java/com/dremio/iceberg/authmgr/oauth2/tokenexchange/SubjectTokenSupplierTest.java
@@ -100,6 +100,45 @@ class SubjectTokenSupplierTest {
     }
   }
 
+  /**
+   * Guards against {@code getStaticToken()} being interned by {@code @Value.Derived}: the token
+   * file must be re-read on every call, so that a file rotated in place by an external process is
+   * picked up without restarting the agent.
+   */
+  @Test
+  void testSupplyTokenAsyncFromRotatedFile(@TempDir Path tempDir) throws Exception {
+    Path tokenFile = tempDir.resolve("subject-token.txt");
+    Files.writeString(tokenFile, "subject-token-v1");
+    OAuth2Config config = createMainConfig(null, tokenFile, TokenTypeURI.JWT, Map.of());
+    try (SubjectTokenSupplier supplier = createSupplier(config)) {
+      assertThat(supplier.supplyTokenAsync())
+          .isCompletedWithValue(
+              new BearerAccessToken("subject-token-v1", 0, null, TokenTypeURI.JWT));
+
+      Files.writeString(tokenFile, "  subject-token-v2  ");
+
+      assertThat(supplier.supplyTokenAsync())
+          .isCompletedWithValue(
+              new BearerAccessToken("subject-token-v2", 0, null, TokenTypeURI.JWT));
+    }
+  }
+
+  @Test
+  void testSupplyTokenAsyncInlineTokenTakesPrecedenceOverFile(@TempDir Path tempDir)
+      throws Exception {
+    Path tokenFile = tempDir.resolve("subject-token.txt");
+    Files.writeString(tokenFile, "subject-token-from-file");
+    OAuth2Config config =
+        createMainConfig("inline-subject-token", tokenFile, TokenTypeURI.JWT, Map.of());
+    try (SubjectTokenSupplier supplier = createSupplier(config)) {
+      // rotating or removing the file must not matter: the inline token wins
+      Files.delete(tokenFile);
+      assertThat(supplier.supplyTokenAsync())
+          .isCompletedWithValue(
+              new BearerAccessToken("inline-subject-token", 0, null, TokenTypeURI.JWT));
+    }
+  }
+
   private static OAuth2Config createMainConfig(
       String subjectToken,
       Path subjectTokenFile,


### PR DESCRIPTION
Assertion files were inadvertently interned due to incorrect use of `@Value.Derived` on the `getStaticAssertion()`.

Token files were not being interned, but rather by accident: the `@Value.Derived` annotation was placed on the _abstract_ method in the parent class, not on the concrete class. So, Immutables was actually silently ignoring it.

This PR fixes both oversights.